### PR TITLE
Add language CLI options for analyzer

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -1134,7 +1134,9 @@ class SeestarStackerGUI:
                 sys.executable,
                 analyzer_script_path,
                 "--input-dir", input_folder,
-                "--command-file", self.analyzer_command_file_path # <-- AJOUTÉ: Passer le chemin fichier commande
+                "--command-file", self.analyzer_command_file_path,
+                "--lang", self.settings.language,
+                "--lock-lang",
             ]
             print(f"DEBUG (GUI): Commande lancement analyseur: {' '.join(command)}") # <-- AJOUTÉ DEBUG
 


### PR DESCRIPTION
## Summary
- add `--lang` and `--lock-lang` CLI options to `analyse_gui.py`
- allow `AstroImageAnalyzerGUI` to specify initial language and lock it
- pass parsed options when launching the GUI
- launch folder analyzer with chosen language and locked state

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68403ac5ca44832fae03b903847b1453