### PR TITLE
Disable trail detection by default

### DIFF
--- a/seestar/beforehand/analyse_gui.py
+++ b/seestar/beforehand/analyse_gui.py
@@ -288,10 +288,12 @@ class AstroImageAnalyzerGUI:
         self.progress_var = tk.DoubleVar(value=0.0) 
 
         # Options d'analyse (Booléens)
-        self.analyze_snr = tk.BooleanVar(value=True) 
-        self.detect_trails = tk.BooleanVar(value=(SATDET_AVAILABLE and SATDET_USES_SEARCHPATTERN))
-        self.sort_by_snr = tk.BooleanVar(value=True) 
-        self.include_subfolders = tk.BooleanVar(value=False) 
+        self.analyze_snr = tk.BooleanVar(value=True)
+        # By default, do not enable trail detection even if the capability is
+        # available. Users can activate it manually.
+        self.detect_trails = tk.BooleanVar(value=False)
+        self.sort_by_snr = tk.BooleanVar(value=True)
+        self.include_subfolders = tk.BooleanVar(value=False)
 
         # Paramètres Sélection SNR
         self.snr_selection_mode = tk.StringVar(value='percent') 


### PR DESCRIPTION
## Summary
- keep the trail detection option unchecked when launching the analyzer

## Testing
- `python -m py_compile seestar/beforehand/analyse_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_68409a12b758832f8644c66e1c17fc90