### PR TITLE
Fix missing import

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -12,6 +12,7 @@ import math
 import os
 from queue import Queue, Empty # Essentiel pour la classe
 import shutil
+import tempfile
 import threading              # Essentiel pour la classe (Lock)
 import time
 import traceback


### PR DESCRIPTION
## Summary
- import `tempfile` in `queue_manager.py`

## Testing
- `python -m py_compile seestar/queuep/queue_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c6ad4fd4832fa0325974b73dca25