### PR TITLE
Fix relative imports for zemosaic

### DIFF
--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -87,7 +87,8 @@ pip install numpy astropy reproject opencv-python photutils scipy psutil
 
 2. 🚀 Launch ZeMosaic
 Once the dependencies are installed:
-python run_zemosaic.py
+python -m zemosaic.run_zemosaic
+Running it as a module ensures internal imports resolve correctly.
 
 The GUI will open. From there:
 
@@ -111,7 +112,8 @@ Click "Start Hierarchical Mosaic"
 🖥️ How to Run
 After installing Python and dependencies:
 
-python run_zemosaic.py
+python -m zemosaic.run_zemosaic
+Running it as a module ensures internal imports resolve correctly.
 Use the GUI to:
 
 Choose your input/output folders

--- a/zemosaic/run_zemosaic.py
+++ b/zemosaic/run_zemosaic.py
@@ -12,8 +12,8 @@ print(f"Chemin de travail actuel (CWD): {sys.path[0]}") # sys.path[0] est géné
 
 # Essayer d'importer la classe GUI et la variable de disponibilité du worker
 try:
-    from zemosaic_gui import ZeMosaicGUI, ZEMOSAIC_WORKER_AVAILABLE
-    print("--- run_zemosaic.py: Import de zemosaic_gui RÉUSSI ---")
+    from .zemosaic_gui import ZeMosaicGUI, ZEMOSAIC_WORKER_AVAILABLE
+    print("--- run_zemosaic.py: Import de zemosaic_gui RÉUSSI (relatif) ---")
 
     # Vérifier le module zemosaic_worker si la GUI dit qu'il est disponible
     if ZEMOSAIC_WORKER_AVAILABLE:
@@ -32,25 +32,30 @@ try:
             print(f"ERREUR (run_zemosaic): zemosaic_worker importé mais n'a pas d'attribut __file__ (très étrange).")
 
 except ImportError as e:
-    print(f"ERREUR CRITIQUE (run_zemosaic): Impossible d'importer ZeMosaicGUI depuis zemosaic_gui.py: {e}")
-    print("  Veuillez vérifier que zemosaic_gui.py est présent et que toutes ses dépendances Python sont installées.")
-    
     try:
-        root_err = tk.Tk()
-        root_err.withdraw()
-        messagebox.showerror("Erreur de Lancement Fatale",
-                             f"Impossible d'importer le module GUI principal (zemosaic_gui.py).\n"
-                             f"Erreur: {e}\n\n"
-                             "Veuillez vérifier les logs console pour plus de détails.")
-        root_err.destroy()
-    except Exception as tk_err:
-        print(f"  Erreur Tkinter lors de la tentative d'affichage de la messagebox: {tk_err}")
-    
-    ZEMOSAIC_WORKER_AVAILABLE = False 
-    ZeMosaicGUI = None
+        from zemosaic_gui import ZeMosaicGUI, ZEMOSAIC_WORKER_AVAILABLE
+        print("--- run_zemosaic.py: Import de zemosaic_gui RÉUSSI (absolu) ---")
+    except ImportError as e2:
+        print(f"ERREUR CRITIQUE (run_zemosaic): Impossible d'importer ZeMosaicGUI depuis zemosaic_gui.py: {e2}")
+        print("  Veuillez vérifier que zemosaic_gui.py est présent et que toutes ses dépendances Python sont installées.")
+
+        try:
+            root_err = tk.Tk()
+            root_err.withdraw()
+            messagebox.showerror("Erreur de Lancement Fatale",
+                                 f"Impossible d'importer le module GUI principal (zemosaic_gui.py).\n"
+                                 f"Erreur: {e2}\n\n"
+                                 "Veuillez vérifier les logs console pour plus de détails.")
+            root_err.destroy()
+        except Exception as tk_err:
+            print(f"  Erreur Tkinter lors de la tentative d'affichage de la messagebox: {tk_err}")
+
+        ZEMOSAIC_WORKER_AVAILABLE = False
+        ZeMosaicGUI = None
 
 print("--- run_zemosaic.py: FIN DES IMPORTS ---")
-print(f"DEBUG (run_zemosaic): sys.path complet: \n{'\n'.join(sys.path)}")
+import os
+print(f"DEBUG (run_zemosaic): sys.path complet: {os.linesep}{os.linesep.join(sys.path)}")
 print("-" * 50)
 
 

--- a/zemosaic/zemosaic_align_stack.py
+++ b/zemosaic/zemosaic_align_stack.py
@@ -63,10 +63,15 @@ except ImportError:
 ZEMOSAIC_UTILS_AVAILABLE_FOR_RADIAL = False
 make_radial_weight_map_func = None
 try:
-    from zemosaic_utils import make_radial_weight_map
+    from .zemosaic_utils import make_radial_weight_map
     make_radial_weight_map_func = make_radial_weight_map
     ZEMOSAIC_UTILS_AVAILABLE_FOR_RADIAL = True
-except ImportError as e_util_rad:
+except Exception:
+    try:
+        from zemosaic_utils import make_radial_weight_map
+        make_radial_weight_map_func = make_radial_weight_map
+        ZEMOSAIC_UTILS_AVAILABLE_FOR_RADIAL = True
+    except ImportError as e_util_rad:
         print(f"AVERT (zemosaic_align_stack): Radial weighting: Erreur import make_radial_weight_map: {e_util_rad}")
 
 

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -26,21 +26,29 @@ except ImportError as e_loc:
 
 # --- Configuration Import ---
 try:
-    import zemosaic_config 
+    from . import zemosaic_config
     ZEMOSAIC_CONFIG_AVAILABLE = True
-except ImportError as e_config:
-    ZEMOSAIC_CONFIG_AVAILABLE = False
-    zemosaic_config = None
-    print(f"AVERTISSEMENT (zemosaic_gui): 'zemosaic_config.py' non trouvé: {e_config}")
+except Exception:
+    try:
+        import zemosaic_config
+        ZEMOSAIC_CONFIG_AVAILABLE = True
+    except ImportError as e_config:
+        ZEMOSAIC_CONFIG_AVAILABLE = False
+        zemosaic_config = None
+        print(f"AVERTISSEMENT (zemosaic_gui): 'zemosaic_config.py' non trouvé: {e_config}")
 
 # --- Worker Import ---
 try:
-    from zemosaic_worker import run_hierarchical_mosaic
+    from .zemosaic_worker import run_hierarchical_mosaic
     ZEMOSAIC_WORKER_AVAILABLE = True
-except ImportError as e_worker:
-    ZEMOSAIC_WORKER_AVAILABLE = False
-    run_hierarchical_mosaic = None
-    print(f"ERREUR (zemosaic_gui): 'run_hierarchical_mosaic' non trouvé: {e_worker}")
+except Exception:
+    try:
+        from zemosaic_worker import run_hierarchical_mosaic
+        ZEMOSAIC_WORKER_AVAILABLE = True
+    except ImportError as e_worker:
+        ZEMOSAIC_WORKER_AVAILABLE = False
+        run_hierarchical_mosaic = None
+        print(f"ERREUR (zemosaic_gui): 'run_hierarchical_mosaic' non trouvé: {e_worker}")
 
 
 

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -61,12 +61,41 @@ zemosaic_utils, ZEMOSAIC_UTILS_AVAILABLE = None, False
 zemosaic_astrometry, ZEMOSAIC_ASTROMETRY_AVAILABLE = None, False
 zemosaic_align_stack, ZEMOSAIC_ALIGN_STACK_AVAILABLE = None, False
 
-try: import zemosaic_utils; ZEMOSAIC_UTILS_AVAILABLE = True; logger.info("Module 'zemosaic_utils' importé.")
-except ImportError as e: logger.error(f"Import 'zemosaic_utils.py' échoué: {e}.")
-try: import zemosaic_astrometry; ZEMOSAIC_ASTROMETRY_AVAILABLE = True; logger.info("Module 'zemosaic_astrometry' importé.")
-except ImportError as e: logger.error(f"Import 'zemosaic_astrometry.py' échoué: {e}.")
-try: import zemosaic_align_stack; ZEMOSAIC_ALIGN_STACK_AVAILABLE = True; logger.info("Module 'zemosaic_align_stack' importé.")
-except ImportError as e: logger.error(f"Import 'zemosaic_align_stack.py' échoué: {e}.")
+try:
+    from . import zemosaic_utils as zemosaic_utils
+    ZEMOSAIC_UTILS_AVAILABLE = True
+    logger.info("Module 'zemosaic_utils' importé (relatif).")
+except Exception:
+    try:
+        import zemosaic_utils as zemosaic_utils
+        ZEMOSAIC_UTILS_AVAILABLE = True
+        logger.info("Module 'zemosaic_utils' importé (absolu).")
+    except ImportError as e:
+        logger.error(f"Import 'zemosaic_utils.py' échoué: {e}.")
+
+try:
+    from . import zemosaic_astrometry as zemosaic_astrometry
+    ZEMOSAIC_ASTROMETRY_AVAILABLE = True
+    logger.info("Module 'zemosaic_astrometry' importé (relatif).")
+except Exception:
+    try:
+        import zemosaic_astrometry as zemosaic_astrometry
+        ZEMOSAIC_ASTROMETRY_AVAILABLE = True
+        logger.info("Module 'zemosaic_astrometry' importé (absolu).")
+    except ImportError as e:
+        logger.error(f"Import 'zemosaic_astrometry.py' échoué: {e}.")
+
+try:
+    from . import zemosaic_align_stack as zemosaic_align_stack
+    ZEMOSAIC_ALIGN_STACK_AVAILABLE = True
+    logger.info("Module 'zemosaic_align_stack' importé (relatif).")
+except Exception:
+    try:
+        import zemosaic_align_stack as zemosaic_align_stack
+        ZEMOSAIC_ALIGN_STACK_AVAILABLE = True
+        logger.info("Module 'zemosaic_align_stack' importé (absolu).")
+    except ImportError as e:
+        logger.error(f"Import 'zemosaic_align_stack.py' échoué: {e}.")
 
 
 


### PR DESCRIPTION
## Summary
- use relative imports with fallbacks in zemosaic modules
- adjust GUI and run script imports
- update README with module launch recommendation

## Testing
- `python -m py_compile zemosaic/zemosaic_worker.py zemosaic/zemosaic_align_stack.py zemosaic/zemosaic_gui.py zemosaic/run_zemosaic.py`

------
https://chatgpt.com/codex/tasks/task_e_6840d4d59b24832f9d933ed832371f16