### PR TITLE
Normalize weight maps

### DIFF
--- a/seestar/core/weights.py
+++ b/seestar/core/weights.py
@@ -29,6 +29,12 @@ def _calculate_image_weights_noise_variance(image_list, progress_callback=None):
             var = std ** 2 if np.isfinite(std) and std > 1e-9 else np.inf
             min_var = var if np.isfinite(var) else 1e-9
             w = (min_var / var if np.isfinite(var) and var > 0 else 1e-6) * np.ones_like(data, dtype=np.float32)
+
+        # Normalise each weight map so its maximum value is 1.0
+        w_max = np.nanmax(w)
+        if np.isfinite(w_max) and w_max > 0:
+            w = w / w_max
+
         weights.append(w)
     return weights
 
@@ -95,5 +101,12 @@ def _calculate_image_weights_noise_fwhm(image_list, progress_callback=None):
         median_fwhm = np.nanmedian(fwhms)
         min_fwhm = max(0.5, np.nanmin(fwhms))
         scalar_weight = min_fwhm / median_fwhm if median_fwhm > 0 else 1.0
-        weights.append(np.full_like(data, scalar_weight, dtype=np.float32))
+        w = np.full_like(data, scalar_weight, dtype=np.float32)
+
+        # Normalise weight map so the maximum equals 1.0
+        w_max = np.nanmax(w)
+        if np.isfinite(w_max) and w_max > 0:
+            w = w / w_max
+
+        weights.append(w)
     return weights

--- a/zemosaic/zemosaic_align_stack.py
+++ b/zemosaic/zemosaic_align_stack.py
@@ -546,15 +546,21 @@ def _calculate_image_weights_noise_variance(image_list: list[np.ndarray | None],
                 weights_for_this_img_array[..., c_idx] = calculated_weight
                 # _pcb(f"WeightNoiseVar: Img {original_image_idx}, Ch {c_idx}, Var={variance_ch:.2e}, PoidsRel={calculated_weight:.3f}", lvl="DEBUG_VERY_DETAIL")
         
+
         elif original_img_data_shape_ref.ndim == 2 and len(variances_for_current_img) == 1: # Monochrome
             variance_mono = variances_for_current_img[0]
             if np.isfinite(variance_mono) and variance_mono > 1e-18:
                 calculated_weight = min_overall_variance / variance_mono
             else:
                 calculated_weight = 1e-6
-            weights_for_this_img_array[:] = calculated_weight # Appliquer à tous les pixels de l'image HW
+            weights_for_this_img_array[:] = calculated_weight  # Appliquer à tous les pixels de l'image HW
             # _pcb(f"WeightNoiseVar: Img {original_image_idx} (Mono), Var={variance_mono:.2e}, PoidsRel={calculated_weight:.3f}", lvl="DEBUG_VERY_DETAIL")
-        
+
+        # Normalisation pour que le poids maximal vaille 1.0
+        w_max = np.nanmax(weights_for_this_img_array)
+        if np.isfinite(w_max) and w_max > 0:
+            weights_for_this_img_array = weights_for_this_img_array / w_max
+
         output_weights_list[original_image_idx] = weights_for_this_img_array
 
     # Pour les images qui n'ont pas pu être traitées (initialement None, ou erreur en cours de route)
@@ -857,8 +863,15 @@ def _calculate_image_weights_noise_fwhm(image_list: list[np.ndarray | None],
             output_weights_list_fwhm[i] = None
         elif i in final_calculated_weights_scalar_fwhm:
             scalar_w_fwhm = final_calculated_weights_scalar_fwhm[i]
-            output_weights_list_fwhm[i] = np.full_like(original_image_data, scalar_w_fwhm, dtype=np.float32)
-        else: 
+            w = np.full_like(original_image_data, scalar_w_fwhm, dtype=np.float32)
+
+            # Normalisation pour que le poids maximal vaille 1.0
+            w_max = np.nanmax(w)
+            if np.isfinite(w_max) and w_max > 0:
+                w = w / w_max
+
+            output_weights_list_fwhm[i] = w
+        else:
             _pcb("weight_fwhm_fallback_weight_one", lvl="DEBUG_DETAIL", img_idx=i)
             output_weights_list_fwhm[i] = np.ones_like(original_image_data, dtype=np.float32)
             


### PR DESCRIPTION
## Summary
- normalize weight maps so each map is scaled to a maximum of 1.0
- add inline comments describing the normalisation step

## Testing
- `python -m py_compile seestar/core/weights.py zemosaic/zemosaic_align_stack.py`

------
https://chatgpt.com/codex/tasks/task_e_68418caef1fc832fb3448624d385dd40