### PR TITLE
Add missing translations for new stack algorithms

### DIFF
--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -77,6 +77,11 @@ EN_TRANSLATIONS = {
     'method_kappa_sigma': "Kappa-Sigma Clip",
     'method_winsorized_sigma_clip': "Winsorized Sigma Clip",
     'method_linear_fit_clip': "Linear Fit Clip",
+    'kappa_sigma': 'Kappa-Sigma Clip',
+    'winsorized_sigma_clip': 'Winsorized Sigma Clip',
+    'linear_fit_clip': 'Linear Fit Clip',
+    'linear_fit': 'Linear Fit (Sky)',
+    'noise_variance': 'Noise Variance (1/σ²)',
 
 
     # SCNR Translations ###

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -76,6 +76,11 @@ FR_TRANSLATIONS = {
     'method_kappa_sigma': "Kappa-Sigma Clip",
     'method_winsorized_sigma_clip': "Winsorized Sigma Clip",
     'method_linear_fit_clip': "Linear Fit Clip",
+    'kappa_sigma': 'Kappa-Sigma Clip',
+    'winsorized_sigma_clip': 'Winsorized Sigma Clip',
+    'linear_fit_clip': 'Linear Fit Clip',
+    'linear_fit': 'Ajustement Linéaire (Fond Ciel)',
+    'noise_variance': 'Variance Bruit (1/σ²)',
     
     ### Traductions SCNR Final ###
     'apply_final_scnr_label': "Appliquer SCNR Final (Vert)",


### PR DESCRIPTION
## Summary
- add translation strings for algorithm names in English and French

## Testing
- `python -m compileall seestar/localization`

------
https://chatgpt.com/codex/tasks/task_e_68419cf1bb1c832f963f7bc1333acab6