### PR TITLE
Add ETA sync to ProgressManager

### DIFF
--- a/seestar/gui/progress.py
+++ b/seestar/gui/progress.py
@@ -27,8 +27,12 @@ class ProgressManager:
         self.progress_bar = progress_bar
         self.status_text = status_text
         self.remaining_time_var = remaining_time_var
+        try:
+            self.remaining_time_var.set("--:--:--")
+        except tk.TclError:
+            pass
         self.elapsed_time_var = elapsed_time_var
-        self.start_time = None 
+        self.start_time = None
         self.timer_id = None
         
         try:
@@ -137,6 +141,14 @@ class ProgressManager:
                  print("Warning: ProgressManager cannot schedule UI update (no valid root).")
         except Exception as e:
              print(f"Error scheduling UI update in ProgressManager: {e}")
+
+    def set_remaining(self, time_str):
+        """Update the remaining time display variable."""
+        try:
+            if hasattr(self.remaining_time_var, 'set'):
+                self.remaining_time_var.set(str(time_str))
+        except tk.TclError:
+            pass
 
 
 

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -834,8 +834,17 @@ class ZeMosaicGUI:
                     def update_eta_label():
                         if hasattr(self.eta_var,'set') and callable(self.eta_var.set):
                             try: self.eta_var.set(eta_string_from_worker)
-                            except tk.TclError: pass 
+                            except tk.TclError: pass
                     if self.root.winfo_exists(): self.root.after_idle(update_eta_label)
+                if hasattr(self, 'progress_manager') and self.progress_manager:
+                    pm = self.progress_manager
+                    if hasattr(pm, 'set_remaining') and callable(pm.set_remaining):
+                        pm.set_remaining(eta_string_from_worker)
+                    elif hasattr(pm, 'remaining_time_var'):
+                        try:
+                            pm.remaining_time_var.set(eta_string_from_worker)
+                        except Exception:
+                            pass
                 is_control_message = True
             elif message_key_or_raw == "CHRONO_START_REQUEST":
                 if self.root.winfo_exists(): self.root.after_idle(self._start_gui_chrono)


### PR DESCRIPTION
## Summary
- initialize `ProgressManager.remaining_time_var` with a default value
- expose `ProgressManager.set_remaining()` helper
- forward ETA updates from `zemosaic_gui` to `ProgressManager`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cbc67e18832fa2b9f73597048087