### PR TITLE
Fix ZeMosaic localization loading

### DIFF
--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -17,7 +17,7 @@ except ImportError:
     print("AVERT GUI: Pillow (PIL) non installé. L'icône PNG ne peut pas être chargée.")
 # --- Import du module de localisation ---
 try:
-    from locales.zemosaic_localization import ZeMosaicLocalization
+    from .locales.zemosaic_localization import ZeMosaicLocalization
     ZEMOSAIC_LOCALIZATION_AVAILABLE = True
 except ImportError as e_loc:
     ZEMOSAIC_LOCALIZATION_AVAILABLE = False


### PR DESCRIPTION
## Summary
- fix local import path to load ZeMosaic translations when run as module

## Testing
- `python -m compileall -q seestar zemosaic`

------
https://chatgpt.com/codex/tasks/task_e_68421548b6d0832f87e2c31c489c5589