### PR TITLE
Remove obsolete ASTAP paths

### DIFF
--- a/zemosaic/zemosaic_config.json
+++ b/zemosaic/zemosaic_config.json
@@ -1,6 +1,4 @@
 {
-    "astap_executable_path": "C:/Program Files/astap/astap.exe",
-    "astap_data_directory_path": "C:/Program Files/astap",
     "astap_default_search_radius": 3.0,
     "astap_default_downsample": 2,
     "astap_default_sensitivity": 100,

--- a/zemosaic/zemosaic_config.py
+++ b/zemosaic/zemosaic_config.py
@@ -6,8 +6,6 @@ import tkinter.messagebox as mb
 
 CONFIG_FILE_NAME = "zemosaic_config.json"
 DEFAULT_CONFIG = {
-    "astap_executable_path": "",
-    "astap_data_directory_path": "", 
     "astap_default_search_radius": 3.0, 
     "astap_default_downsample": 2, 
     "astap_default_sensitivity": 100,
@@ -119,42 +117,6 @@ def save_config(config_data):
 # Assurez-vous que tkinter.filedialog (fd) est importé si vous l'utilisez dans ces fonctions.
 # Par exemple :
 # import tkinter.filedialog as fd # Au début du fichier si ce n'est pas déjà fait globalement
-# ... (vos fonctions ask_and_set_astap_path, etc.)
-
-def ask_and_set_astap_path(current_config):
-    """Demande à l'utilisateur le chemin de l'exécutable ASTAP et met à jour la config."""
-    astap_path = fd.askopenfilename(
-        title="Sélectionner l'exécutable ASTAP",
-        filetypes=(("Fichiers exécutables", "*.exe"), ("Tous les fichiers", "*.*"))
-    )
-    if astap_path:
-        current_config["astap_executable_path"] = astap_path
-        if save_config(current_config):
-            mb.showinfo("Chemin ASTAP Défini", f"Chemin ASTAP défini à : {astap_path}", parent=None) # Spécifier parent si possible
-        return astap_path
-    return current_config.get("astap_executable_path", "")
-
-
-def ask_and_set_astap_data_dir_path(current_config):
-    """Demande à l'utilisateur le chemin du dossier de données ASTAP et met à jour la config."""
-    astap_data_dir = fd.askdirectory(
-        title="Sélectionner le dossier de données ASTAP (contenant G17, H17, etc.)"
-    )
-    if astap_data_dir:
-        current_config["astap_data_directory_path"] = astap_data_dir
-        if save_config(current_config):
-            mb.showinfo("Dossier Données ASTAP Défini", f"Dossier de données ASTAP défini à : {astap_data_dir}", parent=None)
-        return astap_data_dir
-    return current_config.get("astap_data_directory_path", "")
-
-
-def get_astap_executable_path():
-    config = load_config()
-    return config.get("astap_executable_path", "")
-
-def get_astap_data_directory_path():
-    config = load_config()
-    return config.get("astap_data_directory_path", "") # Retourne une chaîne vide si non défini
 
 def get_astap_default_search_radius():
     config = load_config()

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -84,8 +84,7 @@ class ZeMosaicGUI:
         else:
             # Dictionnaire de configuration de secours si zemosaic_config.py n'est pas trouvé
             # ou si le chargement échoue.
-            self.config = { 
-                "astap_executable_path": "", "astap_data_directory_path": "",
+            self.config = {
                 "astap_default_search_radius": 3.0, "astap_default_downsample": 2,
                 "astap_default_sensitivity": 100, "language": "en",
                 "stacking_normalize_method": "none",
@@ -960,8 +959,8 @@ class ZeMosaicGUI:
         # 1. RÉCUPÉRER TOUTES les valeurs des variables Tkinter
         input_dir = self.input_dir_var.get()
         output_dir = self.output_dir_var.get()
-        astap_exe = self.config.get("astap_executable_path", "")
-        astap_data = self.config.get("astap_data_directory_path", "")
+        astap_exe = ""
+        astap_data = ""
         
         try:
             astap_radius_val = self.config.get("astap_default_search_radius", 3.0)


### PR DESCRIPTION
## Summary
- drop ASTAP path options from configuration
- update fallback GUI configuration
- default solver settings now use empty paths

## Testing
- `python -m py_compile zemosaic/zemosaic_config.py zemosaic/zemosaic_gui.py`
- `python zemosaic/run_zemosaic.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_68421f5f0818832fa1172332c534ff0f