### PR TITLE
Forward solver settings to ZeMosaic

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -3191,10 +3191,25 @@ class SeestarStackerGUI:
             # Ensure imports inside run_zemosaic work even if the GUI was
             # started from another directory by using the project root as cwd
             project_root = Path(__file__).resolve().parents[2]
+            env = os.environ.copy()
+            if getattr(self.settings, "astap_path", ""):
+                env["ZEMOSAIC_ASTAP_PATH"] = str(self.settings.astap_path)
+            if getattr(self.settings, "astap_data_dir", ""):
+                env["ZEMOSAIC_ASTAP_DATA_DIR"] = str(self.settings.astap_data_dir)
+            if getattr(self.settings, "local_ansvr_path", ""):
+                env["ZEMOSAIC_LOCAL_ANSVR_PATH"] = str(self.settings.local_ansvr_path)
+            if getattr(self.settings, "astrometry_api_key", ""):
+                env["ZEMOSAIC_ASTROMETRY_API_KEY"] = str(self.settings.astrometry_api_key)
+            try:
+                radius_val = float(getattr(self.settings, "astap_search_radius", 0))
+                env["ZEMOSAIC_ASTAP_SEARCH_RADIUS"] = str(radius_val)
+            except Exception:
+                pass
 
             subprocess.Popen(
                 [sys.executable, "-m", "zemosaic.run_zemosaic"],
                 cwd=str(project_root),
+                env=env,
             )
             self.logger.info("run_zemosaic.py launched successfully")
         except Exception as e:

--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -102,6 +102,20 @@ Adjust stacking & mosaic settings
 
 Click "Start Hierarchical Mosaic"
 
+When ZeMosaic is launched from **Seestar Stacker**, solver settings are
+automatically forwarded via environment variables. You can also set them
+manually before launching:
+
+```
+ZEMOSAIC_ASTAP_PATH=/path/to/astap
+ZEMOSAIC_ASTAP_DATA_DIR=/path/to/catalogs
+ZEMOSAIC_LOCAL_ANSVR_PATH=/path/to/ansvr.cfg
+ZEMOSAIC_ASTROMETRY_API_KEY=your_key
+ZEMOSAIC_ASTAP_SEARCH_RADIUS=3.0
+```
+
+These values prefill the solver configuration when the GUI starts.
+
 📁 Requirements Summary
 ✅ Python 3.9 or newer
 

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -102,6 +102,19 @@ class ZeMosaicGUI:
                 "num_processing_workers": 0 # 0 pour auto, anciennement -1
             }
 
+        self.env_solver_settings = {
+            'astap_path': os.environ.get('ZEMOSAIC_ASTAP_PATH'),
+            'astap_data_dir': os.environ.get('ZEMOSAIC_ASTAP_DATA_DIR'),
+            'local_ansvr_path': os.environ.get('ZEMOSAIC_LOCAL_ANSVR_PATH'),
+            'api_key': os.environ.get('ZEMOSAIC_ASTROMETRY_API_KEY'),
+            'astap_search_radius': None,
+        }
+        if os.environ.get('ZEMOSAIC_ASTAP_SEARCH_RADIUS'):
+            try:
+                self.env_solver_settings['astap_search_radius'] = float(os.environ['ZEMOSAIC_ASTAP_SEARCH_RADIUS'])
+            except ValueError:
+                self.env_solver_settings['astap_search_radius'] = None
+
         default_lang_from_config = self.config.get("language", 'en')
         if ZEMOSAIC_LOCALIZATION_AVAILABLE and ZeMosaicLocalization:
             self.localizer = ZeMosaicLocalization(language_code=default_lang_from_config)
@@ -959,11 +972,14 @@ class ZeMosaicGUI:
         # 1. RÉCUPÉRER TOUTES les valeurs des variables Tkinter
         input_dir = self.input_dir_var.get()
         output_dir = self.output_dir_var.get()
-        astap_exe = ""
-        astap_data = ""
+        astap_exe = self.env_solver_settings.get('astap_path') or ""
+        astap_data = self.env_solver_settings.get('astap_data_dir') or ""
         
         try:
-            astap_radius_val = self.config.get("astap_default_search_radius", 3.0)
+            if self.env_solver_settings.get('astap_search_radius') is not None:
+                astap_radius_val = self.env_solver_settings['astap_search_radius']
+            else:
+                astap_radius_val = self.config.get("astap_default_search_radius", 3.0)
             astap_downsample_val = self.config.get("astap_default_downsample", 2)
             astap_sensitivity_val = self.config.get("astap_default_sensitivity", 100)
             cluster_thresh_val = self.cluster_threshold_var.get()
@@ -1037,6 +1053,8 @@ class ZeMosaicGUI:
             'astap_search_radius': astap_radius_val,
             'astap_downsample': astap_downsample_val,
             'astap_sensitivity': astap_sensitivity_val,
+            'api_key': self.env_solver_settings.get('api_key'),
+            'local_ansvr_path': self.env_solver_settings.get('local_ansvr_path'),
         }
 
         worker_args = (

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -1178,6 +1178,13 @@ def run_hierarchical_mosaic(
     PROGRESS_WEIGHT_PHASE7_CLEANUP = 2
     current_global_progress = 0
     smoothed_eta = None
+
+    solver_settings = solver_settings.copy() if isinstance(solver_settings, dict) else {}
+    astap_exe_path = solver_settings.get('astap_path', '')
+    astap_data_dir_param = solver_settings.get('astap_data_dir')
+    astap_search_radius_config = solver_settings.get('astap_search_radius', 3.0)
+    api_key_param = solver_settings.get('api_key')
+    local_ansvr_path_param = solver_settings.get('local_ansvr_path')
     
     error_messages_deps = []
     if not (ASTROPY_AVAILABLE and WCS and SkyCoord and Angle and fits and u): error_messages_deps.append("Astropy")
@@ -1207,23 +1214,20 @@ def run_hierarchical_mosaic(
 
     # --- Initialisation du solveur astrométrique ---
     astrometry_solver = None
-    solver_settings = {}
     if ASTROMETRY_SOLVER_AVAILABLE:
         try:
             astrometry_solver = AstrometrySolver(progress_callback=progress_callback)
-            solver_settings = {
-                'local_solver_preference': 'astap',
-                'api_key': None,
-                'astap_path': astap_exe_path,
-                'astap_data_dir': astap_data_dir_param,
-                'astap_search_radius': astap_search_radius_config,
-                'local_ansvr_path': None,
-                'scale_est_arcsec_per_pix': None,
-                'scale_tolerance_percent': 20,
-                'ansvr_timeout_sec': 120,
-                'astap_timeout_sec': 180,
-                'astrometry_net_timeout_sec': 300,
-            }
+            solver_settings.setdefault('local_solver_preference', 'astap')
+            solver_settings.setdefault('api_key', api_key_param)
+            solver_settings.setdefault('astap_path', astap_exe_path)
+            solver_settings.setdefault('astap_data_dir', astap_data_dir_param)
+            solver_settings.setdefault('astap_search_radius', astap_search_radius_config)
+            solver_settings.setdefault('local_ansvr_path', local_ansvr_path_param)
+            solver_settings.setdefault('scale_est_arcsec_per_pix', None)
+            solver_settings.setdefault('scale_tolerance_percent', 20)
+            solver_settings.setdefault('ansvr_timeout_sec', 120)
+            solver_settings.setdefault('astap_timeout_sec', 180)
+            solver_settings.setdefault('astrometry_net_timeout_sec', 300)
         except Exception as e_solver_inst:
             pcb("run_warn_solver_init_failed", prog=None, lvl="WARN", error=str(e_solver_inst))
             astrometry_solver = None


### PR DESCRIPTION
## Summary
- pass solver configuration as environment variables when launching ZeMosaic
- pre-read those variables in ZeMosaic GUI for default solver values
- use provided solver settings in worker
- document environment variables in README

## Testing
- `python -m py_compile seestar/gui/main_window.py zemosaic/zemosaic_gui.py zemosaic/zemosaic_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_6842294ec0b8832f9dc068862b7f3155