### PR TITLE
Forward solver preference to ZeMosaic

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -3200,6 +3200,8 @@ class SeestarStackerGUI:
                 env["ZEMOSAIC_LOCAL_ANSVR_PATH"] = str(self.settings.local_ansvr_path)
             if getattr(self.settings, "astrometry_api_key", ""):
                 env["ZEMOSAIC_ASTROMETRY_API_KEY"] = str(self.settings.astrometry_api_key)
+            if getattr(self.settings, "local_solver_preference", ""):
+                env["ZEMOSAIC_LOCAL_SOLVER_PREFERENCE"] = str(self.settings.local_solver_preference)
             try:
                 radius_val = float(getattr(self.settings, "astap_search_radius", 0))
                 env["ZEMOSAIC_ASTAP_SEARCH_RADIUS"] = str(radius_val)

--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -112,6 +112,7 @@ ZEMOSAIC_ASTAP_DATA_DIR=/path/to/catalogs
 ZEMOSAIC_LOCAL_ANSVR_PATH=/path/to/ansvr.cfg
 ZEMOSAIC_ASTROMETRY_API_KEY=your_key
 ZEMOSAIC_ASTAP_SEARCH_RADIUS=3.0
+ZEMOSAIC_LOCAL_SOLVER_PREFERENCE=astap
 ```
 
 These values prefill the solver configuration when the GUI starts.

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -107,6 +107,7 @@ class ZeMosaicGUI:
             'astap_data_dir': os.environ.get('ZEMOSAIC_ASTAP_DATA_DIR'),
             'local_ansvr_path': os.environ.get('ZEMOSAIC_LOCAL_ANSVR_PATH'),
             'api_key': os.environ.get('ZEMOSAIC_ASTROMETRY_API_KEY'),
+            'local_solver_preference': os.environ.get('ZEMOSAIC_LOCAL_SOLVER_PREFERENCE'),
             'astap_search_radius': None,
         }
         if os.environ.get('ZEMOSAIC_ASTAP_SEARCH_RADIUS'):
@@ -1047,7 +1048,7 @@ class ZeMosaicGUI:
         # ... (autres logs d'info) ...
 
         solver_settings = {
-            'local_solver_preference': 'astap',
+            'local_solver_preference': self.env_solver_settings.get('local_solver_preference', 'none'),
             'astap_path': astap_exe,
             'astap_data_dir': astap_data,
             'astap_search_radius': astap_radius_val,


### PR DESCRIPTION
## Summary
- forward `local_solver_preference` to `run_zemosaic`
- read solver preference from environment in `ZeMosaicGUI`
- use that preference when starting processing
- document `ZEMOSAIC_LOCAL_SOLVER_PREFERENCE` env variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68422ddb89a4832fb7f23ae055d1624d