### PR TITLE
Add reproject install guidance

### DIFF
--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -85,6 +85,13 @@ If you prefer to install manually:
 
 pip install numpy astropy reproject opencv-python photutils scipy psutil
 
+The mosaic assembly routines require the **reproject** package. If you encounter
+errors about missing `reproject`, install it with:
+
+```bash
+pip install reproject
+```
+
 2. 🚀 Launch ZeMosaic
 Once the dependencies are installed:
 python -m zemosaic.run_zemosaic

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -61,8 +61,22 @@ try:
     find_optimal_celestial_wcs, reproject_and_coadd, reproject_interp = actual_find_optimal_wcs, actual_reproject_coadd, actual_reproject_interp
     REPROJECT_AVAILABLE = True
     logger.info("Bibliothèque 'reproject' importée.")
-except ImportError as e_reproject_final: logger.critical(f"Échec import reproject: {e_reproject_final}.")
-except Exception as e_reproject_other_final: logger.critical(f"Erreur import 'reproject': {e_reproject_other_final}", exc_info=True)
+except ImportError as e_reproject_final:
+    logger.critical(
+        f"Échec import reproject: {e_reproject_final}."
+    )
+    logger.critical(
+        "Veuillez installer le paquet 'reproject' (pip install reproject)."
+    )
+except Exception as e_reproject_other_final:
+    logger.critical(
+        f"Erreur import 'reproject': {e_reproject_other_final}", exc_info=True
+    )
+
+if not REPROJECT_AVAILABLE:
+    logger.error(
+        "Le module 'reproject' est requis. Installez-le via 'pip install reproject'."
+    )
 
 # --- Local Project Module Imports ---
 zemosaic_utils, ZEMOSAIC_UTILS_AVAILABLE = None, False


### PR DESCRIPTION
## Summary
- log guidance to install `reproject` when missing
- explain the `reproject` requirement in ZeMosaic README

## Testing
- `python -m py_compile zemosaic/zemosaic_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_6842b1f8dafc832fb63e0cdabea425a1