### PR TITLE
Add verbose logging toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Lorsque vous lancez l'application, elle effectue des vérifications pour voir si
 **(English)**
 
 1.  **Run the Application:** Navigate to the project's root directory and run `python seestar/main.py`.
+    Set the environment variable `SEESTAR_VERBOSE=1` (or pass `-v` when running
+    `run_zemosaic.py`) to enable verbose debug output.
 2.  **Select Folders:** Choose Input, Output, and optional Reference folders/files.
 3.  **Adjust Stacking Settings:** Select Method, Kappa, Batch Size, Hot Pixel options, Quality Weighting parameters, and Cleanup preference.
 4.  **Adjust Preview (Optional):** Modify preview display settings (WB, Stretch, Gamma, etc.) using the Preview tab and Histogram. *This does not affect the final FITS stack.*
@@ -220,6 +222,8 @@ Lorsque vous lancez l'application, elle effectue des vérifications pour voir si
 **(Français)**
 
 1.  **Lancer l'Application :** Naviguez vers le répertoire racine du projet et exécutez `python seestar/main.py`.
+    Définissez la variable d'environnement `SEESTAR_VERBOSE=1` (ou utilisez
+    l'option `-v` avec `run_zemosaic.py`) pour activer les messages de débogage détaillés.
 2.  **Sélectionner les Dossiers :** Choisissez les dossiers d'Entrée, de Sortie et optionnellement le fichier de Référence.
 3.  **Ajuster les Paramètres d'Empilement :** Sélectionnez la Méthode, Kappa, Taille de Lot, options de Pixels Chauds, paramètres de Pondération par Qualité et préférence de Nettoyage.
 4.  **Ajuster l'Aperçu (Optionnel) :** Modifiez les paramètres d'affichage de l'aperçu (BdB, Étirement, Gamma, etc.) via l'onglet Aperçu et l'Histogramme. *Ceci n'affecte pas le stack FITS final sauvegardé.*

--- a/seestar/alignment/astrometry_solver.py
+++ b/seestar/alignment/astrometry_solver.py
@@ -241,13 +241,16 @@ class AstrometrySolver:
     """
     Classe pour orchestrer la résolution astrométrique en utilisant différents solveurs.
     """
-    def __init__(self, progress_callback=None, verbose=False):
+    def __init__(self, progress_callback=None, verbose=None):
         """
         Initialise le solveur.
         Args:
             progress_callback (callable, optional): Callback pour les messages de progression.
         """
         self.progress_callback = progress_callback
+        if verbose is None:
+            _v_env = os.getenv("SEESTAR_VERBOSE", "")
+            verbose = str(_v_env).lower() in ("1", "true", "yes")
         self.verbose = verbose
         self.logger = logger
         if not _ASTROPY_AVAILABLE:

--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -124,6 +124,9 @@ ZEMOSAIC_ASTAP_SEARCH_RADIUS=3.0
 ZEMOSAIC_LOCAL_SOLVER_PREFERENCE=astap
 ```
 
+Set `SEESTAR_VERBOSE=1` or use the `-v` flag when launching `run_zemosaic.py` to
+see detailed debug logs.
+
 These values prefill the solver configuration when the GUI starts.
 
 📁 Requirements Summary

--- a/zemosaic/run_zemosaic.py
+++ b/zemosaic/run_zemosaic.py
@@ -3,9 +3,19 @@ import sys  # Ajout pour sys.path et sys.modules
 # import reproject # L'import direct ici n'est pas crucial, mais ne fait pas de mal
 import tkinter as tk
 from tkinter import messagebox  # Nécessaire pour la messagebox d'erreur critique
+import os
 import logging
 
-logging.basicConfig(level=logging.INFO)
+# Determine verbosity from environment variable or command-line flag
+_verbose_env = os.getenv("SEESTAR_VERBOSE", "")
+_verbose_flag = "-v" in sys.argv or "--verbose" in sys.argv
+if _verbose_flag:
+    # Remove the flag so Tkinter doesn't see it
+    sys.argv = [a for a in sys.argv if a not in ("-v", "--verbose")]
+log_level = logging.DEBUG if (
+    _verbose_flag or str(_verbose_env).lower() in ("1", "true", "yes")
+) else logging.INFO
+logging.basicConfig(level=log_level)
 logger = logging.getLogger("ZeMosaicRunner")
 
 # --- Impression de débogage initiale ---


### PR DESCRIPTION
## Summary
- add SEESTAR_VERBOSE flag support in astrometry solver and ZeMosaic runner
- document how to enable verbose logs

## Testing
- `pytest -q`
- `python -m py_compile zemosaic/run_zemosaic.py seestar/alignment/astrometry_solver.py`


------
https://chatgpt.com/codex/tasks/task_e_6842bba15b88832fb0cd83bd40a78a09