### PR TITLE
Handle missing shapely gracefully

### DIFF
--- a/zemosaic/requirements.txt
+++ b/zemosaic/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 astropy
 reproject
+shapely
 astroalign
 opencv-python-headless
 tk

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -53,6 +53,7 @@ except Exception as e_astro_other_imp: logger.critical(f"Erreur import Astropy: 
 
 # --- Reproject (critique pour la mosaïque) ---
 REPROJECT_AVAILABLE = False
+SHAPELY_AVAILABLE = True
 find_optimal_celestial_wcs, reproject_and_coadd, reproject_interp = None, None, None
 try:
     from reproject.mosaicking import find_optimal_celestial_wcs as actual_find_optimal_wcs
@@ -72,6 +73,17 @@ except Exception as e_reproject_other_final:
     logger.critical(
         f"Erreur import 'reproject': {e_reproject_other_final}", exc_info=True
     )
+
+if REPROJECT_AVAILABLE:
+    try:
+        from shapely.geometry import Point  # noqa: F401 - simple availability check
+        logger.info("Bibliothèque 'shapely' détectée.")
+    except Exception as e_shapely:
+        SHAPELY_AVAILABLE = False
+        find_optimal_celestial_wcs = None
+        logger.warning(
+            "Module 'shapely' manquant: find_optimal_celestial_wcs sera ignoré."
+        )
 
 if not REPROJECT_AVAILABLE:
     logger.error(


### PR DESCRIPTION
## Summary
- avoid `find_optimal_celestial_wcs` when shapely is missing
- note shapely requirement for the mosaic tool

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842da6475f4832fbb4f28773bcfe012