### PR TITLE
Add astrometry_method option

### DIFF
--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -122,7 +122,12 @@ ZEMOSAIC_LOCAL_ANSVR_PATH=/path/to/ansvr.cfg
 ZEMOSAIC_ASTROMETRY_API_KEY=your_key
 ZEMOSAIC_ASTAP_SEARCH_RADIUS=3.0
 ZEMOSAIC_LOCAL_SOLVER_PREFERENCE=astap
+ZEMOSAIC_ASTROMETRY_METHOD=astap
 ```
+
+`ZEMOSAIC_ASTROMETRY_METHOD` accepts `astap`, `astrometry`, or `astrometry.net`.
+`astrometry` and `astrometry.net` will use ansvr when a local path is provided,
+otherwise they fall back to the online solver.
 
 Set `SEESTAR_VERBOSE=1` or use the `-v` flag when launching `run_zemosaic.py` to
 see detailed debug logs.

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -1362,6 +1362,21 @@ def run_hierarchical_mosaic(
     astap_search_radius_config = solver_settings.get('astap_search_radius', 3.0)
     api_key_param = solver_settings.get('api_key')
     local_ansvr_path_param = solver_settings.get('local_ansvr_path')
+    astrometry_method_param = solver_settings.get('astrometry_method')
+
+    if astrometry_method_param:
+        method_norm = str(astrometry_method_param).strip().lower()
+        if method_norm == 'astap':
+            solver_settings['local_solver_preference'] = 'astap'
+        elif method_norm in ('astrometry', 'astrometry.net'):
+            solver_settings['local_solver_preference'] = (
+                'ansvr' if local_ansvr_path_param else 'none'
+            )
+        pcb(
+            f"  Config Solver Method: '{method_norm}' -> '{solver_settings['local_solver_preference']}'",
+            prog=None,
+            lvl="DEBUG_DETAIL",
+        )
     
     error_messages_deps = []
     if not (ASTROPY_AVAILABLE and WCS and SkyCoord and Angle and fits and u): error_messages_deps.append("Astropy")


### PR DESCRIPTION
## Summary
- support `astrometry_method` in `run_hierarchical_mosaic`
- map astrometry method keywords to solver preference
- document the new environment variable and keywords

## Testing
- `python -m py_compile zemosaic/zemosaic_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_6842e6e3243c832f8bd62af8745747f2