### PR TITLE
Enable optional WCS re-solving of cropped tiles

### DIFF
--- a/tests/test_mosaic_worker.py
+++ b/tests/test_mosaic_worker.py
@@ -52,6 +52,8 @@ def test_crop_pixel_shape_passed(monkeypatch, tmp_path):
     monkeypatch.setattr(worker, "REPROJECT_AVAILABLE", True)
     monkeypatch.setattr(worker, "reproject_interp", lambda input_data, output_projection, shape_out=None, order='bilinear', parallel=False: (input_data[0], np.ones(shape_out)))
     monkeypatch.setattr(worker, "ZEMOSAIC_UTILS_AVAILABLE", True)
+    monkeypatch.setattr(worker, "ASTROMETRY_SOLVER_AVAILABLE", True)
+    monkeypatch.setattr(worker, "ASTROMETRY_SOLVER_AVAILABLE", True)
 
     class DummyZU:
         @staticmethod
@@ -98,4 +100,75 @@ def test_crop_pixel_shape_passed(monkeypatch, tmp_path):
         crop_percent=10.0,
     )
 
+    assert captured.get("pixel_shapes") == [(80, 80)]
+
+
+def test_resolve_after_crop(monkeypatch, tmp_path):
+    importlib.reload(worker)
+
+    monkeypatch.setattr(worker, "REPROJECT_AVAILABLE", True)
+    monkeypatch.setattr(
+        worker,
+        "reproject_interp",
+        lambda input_data, output_projection, shape_out=None, order="bilinear", parallel=False: (input_data[0], np.ones(shape_out)),
+    )
+    monkeypatch.setattr(worker, "ZEMOSAIC_UTILS_AVAILABLE", True)
+    monkeypatch.setattr(worker, "ASTROMETRY_SOLVER_AVAILABLE", True)
+
+    class DummyZU:
+        @staticmethod
+        def crop_image_and_wcs(image_data, wcs_obj, crop_fraction, progress_callback=None):
+            h, w = image_data.shape[:2]
+            dh = int(h * crop_fraction)
+            dw = int(w * crop_fraction)
+            cropped = image_data[dh:h-dh, dw:w-dw, :]
+            new_wcs = wcs_obj.copy()
+            new_wcs.pixel_shape = (cropped.shape[1], cropped.shape[0])
+            return cropped, new_wcs
+
+    monkeypatch.setattr(worker, "zemosaic_utils", DummyZU)
+
+    data = np.ones((1, 100, 100), dtype=np.float32)
+    fits_path = tmp_path / "tile.fits"
+    from astropy.io import fits
+    fits.writeto(fits_path, data, overwrite=True)
+
+    wcs_in = make_wcs(0, 0, shape=(100, 100))
+
+    class DummySolver:
+        def __init__(self):
+            self.called = False
+
+        def solve(self, image_path, fits_header, settings, update_header_with_solution=True):
+            self.called = True
+            return make_wcs(1, 1, shape=(80, 80))
+
+    dummy_solver = DummySolver()
+
+    captured = {}
+
+    def dummy_reproject_and_coadd(input_data, output_projection, shape_out, reproject_function=None, combine_function="mean", match_background=True, **kwargs):
+        captured["pixel_shapes"] = [w.pixel_shape for _, w in input_data]
+        return np.zeros(shape_out, dtype=np.float32), np.zeros(shape_out, dtype=np.float32)
+
+    monkeypatch.setattr(worker, "reproject_and_coadd", dummy_reproject_and_coadd)
+
+    final_wcs = make_wcs(0, 0, shape=(80, 80))
+    final_shape = (80, 80)
+
+    worker.assemble_final_mosaic_with_reproject_coadd(
+        [(str(fits_path), wcs_in)],
+        final_wcs,
+        final_shape,
+        progress_callback=None,
+        n_channels=1,
+        match_bg=False,
+        apply_crop=True,
+        crop_percent=10.0,
+        re_solve_cropped_tiles=True,
+        solver_settings={},
+        solver_instance=dummy_solver,
+    )
+
+    assert dummy_solver.called
     assert captured.get("pixel_shapes") == [(80, 80)]


### PR DESCRIPTION
## Summary
- add optional `re_solve_cropped_tiles` feature in `assemble_final_mosaic_with_reproject_coadd`
- propagate new option via `run_hierarchical_mosaic`
- implement WCS re-solving logic using a provided solver instance
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ecff863c832f9936baca4ecfdd47