### PR TITLE
Fix asinh_a parameter name

### DIFF
--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -2111,11 +2111,10 @@ def run_hierarchical_mosaic(
 
                 m_stretched = zemosaic_utils.stretch_auto_asifits_like(
                     final_mosaic_data_HWC,
-                    p_low=preview_p_low, 
+                    p_low=preview_p_low,
                     p_high=preview_p_high,
-                    asinh_a_factor=preview_asinh_a, # Renommé pour correspondre à une signature possible
-                    # ou simplement asinh_a=preview_asinh_a si la fonction s'appelle ainsi
-                    apply_wb=True # Supposons que tu veuilles la balance des blancs auto
+                    asinh_a=preview_asinh_a,  # correspond à la signature de la fonction
+                    apply_wb=True  # Supposons que tu veuilles la balance des blancs auto
                 )
 
                 if m_stretched is not None:


### PR DESCRIPTION
## Summary
- in zemosaic_worker use `asinh_a` instead of deprecated `asinh_a_factor` when generating preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f4612f0c832fbd749410922caccf