### PR TITLE
Add option to re-solve cropped tiles

### DIFF
--- a/zemosaic/locales/en.json
+++ b/zemosaic/locales/en.json
@@ -22,6 +22,7 @@
     "apply_master_tile_crop_label": "Crop Master Tile Edges:",
     "master_tile_crop_percent_label": "Crop Percentage per Side (0-25%):",
     "master_tile_crop_percent_note": "(0.0 = no crop)",
+    "re_solve_cropped_tiles_label": "Re-solve Cropped Tiles:",
 
 
     "config_warning_title": "Config Warning",

--- a/zemosaic/locales/fr.json
+++ b/zemosaic/locales/fr.json
@@ -22,7 +22,8 @@
     "crop_options_frame_title": "Options de Rognage des Tuiles Maîtresses",
     "apply_master_tile_crop_label": "Rogner les Bords des Tuiles Maîtresses :",
     "master_tile_crop_percent_label": "Pourcentage de Rognage par Côté (0-25%) :",
-    "master_tile_crop_percent_note": "(0.0 = pas de rognage)",    
+    "master_tile_crop_percent_note": "(0.0 = pas de rognage)",
+    "re_solve_cropped_tiles_label": "Re-résoudre les Tuiles Rognées :",
 
 
     "config_warning_title": "Avertissement Configuration",

--- a/zemosaic/zemosaic_config.py
+++ b/zemosaic/zemosaic_config.py
@@ -26,7 +26,8 @@ DEFAULT_CONFIG = {
     # --- CLES POUR LE ROGNAGE DES MASTER TUILES ---
     "apply_master_tile_crop": True,       # Désactivé par défaut
     "master_tile_crop_percent": 18.0      # Pourcentage par côté si activé (ex: 10%)
-    # --- FIN CLES POUR LE ROGNAGE --- 
+    "re_solve_cropped_tiles": False,
+    # --- FIN CLES POUR LE ROGNAGE ---
 }
 
 def get_config_path():

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -206,6 +206,9 @@ class ZeMosaicGUI:
         self.master_tile_crop_percent_var = tk.DoubleVar(
             value=self.config.get("master_tile_crop_percent", 18.0) # 18% par côté par défaut si activé
         )
+        self.re_solve_cropped_tiles_var = tk.BooleanVar(
+            value=self.config.get("re_solve_cropped_tiles", False)
+        )
         # ---  ---
 
         self.translatable_widgets = {}
@@ -550,6 +553,18 @@ class ZeMosaicGUI:
         crop_percent_note.grid(row=crop_opt_row, column=2, padx=(10,5), pady=3, sticky="ew")
         self.translatable_widgets["master_tile_crop_percent_note"] = crop_percent_note
         crop_opt_row += 1
+
+        self.re_solve_crop_label = ttk.Label(crop_options_frame, text="")
+        self.re_solve_crop_label.grid(row=crop_opt_row, column=0, padx=5, pady=3, sticky="w")
+        self.translatable_widgets["re_solve_cropped_tiles_label"] = self.re_solve_crop_label
+
+        self.re_solve_crop_check = ttk.Checkbutton(
+            crop_options_frame,
+            variable=self.re_solve_cropped_tiles_var
+        )
+        self.re_solve_crop_check.grid(row=crop_opt_row, column=1, padx=5, pady=3, sticky="w")
+        crop_opt_row += 1
+        self._update_crop_options_state()
         # --- FIN  CADRE DE ROGNAGE ---
 
         # --- Options d'Assemblage Final ---
@@ -707,16 +722,19 @@ class ZeMosaicGUI:
     def _update_crop_options_state(self, *args):
         """Active ou désactive le spinbox de pourcentage de rognage."""
         if not all(hasattr(self, attr) for attr in [
-            'apply_master_tile_crop_var', 
-            'crop_percent_spinbox'
+            'apply_master_tile_crop_var',
+            'crop_percent_spinbox',
+            're_solve_crop_check'
         ]):
             return # Widgets pas encore prêts
 
         try:
             if self.apply_master_tile_crop_var.get():
                 self.crop_percent_spinbox.config(state=tk.NORMAL)
+                self.re_solve_crop_check.config(state=tk.NORMAL)
             else:
                 self.crop_percent_spinbox.config(state=tk.DISABLED)
+                self.re_solve_crop_check.config(state=tk.DISABLED)
         except tk.TclError:
             pass # Widget peut avoir été détruit
 
@@ -1112,7 +1130,8 @@ class ZeMosaicGUI:
             # --- NOUVEAUX ARGUMENTS POUR LE ROGNAGE ---
             apply_master_tile_crop_val,
             master_tile_crop_percent_val,
-            self.save_final_uint16_var.get()
+            self.save_final_uint16_var.get(),
+            self.re_solve_cropped_tiles_var.get()
             # --- FIN NOUVEAUX ARGUMENTS ---
         )
         


### PR DESCRIPTION
## Summary
- include `re_solve_cropped_tiles` in default config
- surface the new option in the GUI crop section
- localize label for English and French
- forward checkbox value to the worker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f615d0e4832fb6ce0899a29bef50