### PR TITLE
Document solver_settings usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,37 @@ python -m seestar.scripts.run_mosaic INPUT_DIR OUTPUT_DIR \
 ```
 
 Solver options correspond to the `ZEMOSAIC_*` environment variables used by the GUI.
+When calling the worker from Python, gather them into a `solver_settings` dictionary:
+
+```python
+from zemosaic import zemosaic_worker
+
+solver_settings = {
+    "astap_path": "/path/to/astap",
+    "astap_data_dir": "/path/to/catalogs",
+    "astap_search_radius": 3.0,
+    "astap_downsample": 2,
+    "astap_sensitivity": 100,
+    "local_ansvr_path": "/path/to/ansvr.cfg",
+    "api_key": "your_key",
+    "local_solver_preference": "astap",
+}
+
+zemosaic_worker.run_hierarchical_mosaic(
+    "INPUT_DIR", "OUTPUT_DIR", solver_settings, cluster_threshold=0.5, ...
+)
+```
+
+**`solver_settings` keys**
+
+- `astap_path`: path to the ASTAP executable
+- `astap_data_dir`: directory containing ASTAP star catalogs
+- `astap_search_radius`: search radius in degrees passed to ASTAP
+- `astap_downsample`: downsample factor used by ASTAP
+- `astap_sensitivity`: detection sensitivity percentage for ASTAP
+- `local_ansvr_path`: path to a local `ansvr.cfg`
+- `api_key`: astrometry.net API key
+- `local_solver_preference`: preferred local solver (`astap` or `ansvr`)
 
 ---
 

--- a/seestar/scripts/run_mosaic.py
+++ b/seestar/scripts/run_mosaic.py
@@ -15,7 +15,11 @@ from zemosaic import zemosaic_config, zemosaic_worker
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Run the hierarchical mosaic process on a folder of FITS files",
+        description=(
+            "Run the hierarchical mosaic process on a folder of FITS files. "
+            "Solver options are gathered into a solver_settings dict and passed "
+            "to run_hierarchical_mosaic."
+        ),
     )
     parser.add_argument("input_folder", help="Directory containing FITS tiles")
     parser.add_argument("output_folder", help="Directory where results are written")

--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -134,6 +134,32 @@ see detailed debug logs.
 
 These values prefill the solver configuration when the GUI starts.
 
+If you invoke the worker manually, supply the same options via a
+`solver_settings` dictionary:
+
+```python
+solver_settings = {
+    "astap_path": "/path/to/astap",
+    "astap_data_dir": "/path/to/catalogs",
+    "astap_search_radius": 3.0,
+    "astap_downsample": 2,
+    "astap_sensitivity": 100,
+    "local_ansvr_path": "/path/to/ansvr.cfg",
+    "api_key": "your_key",
+    "local_solver_preference": "astap",
+}
+```
+
+Keys are the same used by the GUI:
+- `astap_path` – ASTAP executable
+- `astap_data_dir` – folder with ASTAP star catalogs
+- `astap_search_radius` – search radius in degrees
+- `astap_downsample` – ASTAP downsample factor
+- `astap_sensitivity` – ASTAP detection sensitivity
+- `local_ansvr_path` – path to `ansvr.cfg`
+- `api_key` – astrometry.net API key
+- `local_solver_preference` – preferred local solver
+
 📁 Requirements Summary
 ✅ Python 3.9 or newer
 

--- a/zemosaic/run_zemosaic.py
+++ b/zemosaic/run_zemosaic.py
@@ -90,7 +90,11 @@ logger.debug("-" * 50)
 
 def _parse_cli_args():
     parser = argparse.ArgumentParser(
-        description="Run ZeMosaic either via the GUI (default) or headless CLI",
+        description=(
+            "Run ZeMosaic either via the GUI (default) or headless CLI. "
+            "Solver parameters are collected into a solver_settings dictionary "
+            "and forwarded to run_hierarchical_mosaic."
+        ),
         add_help=True,
     )
     parser.add_argument("input_folder", nargs="?", help="Folder with FITS images")


### PR DESCRIPTION
## Summary
- document solver_settings dict in README and zemosaic/README
- mention solver_settings usage in CLI help text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843499e9f50832f905dc5b588453df3