### PR TITLE
Ensure FOV radius uses two decimal precision

### DIFF
--- a/seestar/alignment/astrometry_solver.py
+++ b/seestar/alignment/astrometry_solver.py
@@ -684,8 +684,9 @@ class AstrometrySolver:
             # Pour l'instant, on passe -r si fourni, sinon on laisse ASTAP gérer.
             # Le comportement exact de -r sans -ra -dec est à confirmer via les logs ASTAP.
             # Le log d'ASTAP devrait indiquer "Search an area of X degrees around image center"
-            cmd.extend(["-r", str(astap_search_radius_deg)])
-            self._log(f"ASTAP: Utilisation rayon de recherche: {astap_search_radius_deg}°", "DEBUG")
+            radius_str = f"{float(astap_search_radius_deg):.2f}"
+            cmd.extend(["-r", radius_str])
+            self._log(f"ASTAP: Utilisation rayon de recherche: {radius_str}°", "DEBUG")
         else:
             # Si astap_search_radius_deg est 0 ou non fourni, ASTAP utilisera -fov 0
             # ce qui est généralement recommandé pour une recherche "aveugle".

--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -202,7 +202,15 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         ttk.Entry(astap_data_subframe, textvariable=self.astap_data_dir_var).pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(5,0))
         astap_radius_subframe = ttk.Frame(self.astap_frame); astap_radius_subframe.pack(fill=tk.X, pady=(2,5))
         ttk.Label(astap_radius_subframe, text=self.parent_gui.tr("local_solver_astap_radius_label", default="ASTAP Search Radius (degrees, 0 for auto):"), width=35, anchor="w").pack(side=tk.LEFT, padx=(0,5))
-        ttk.Spinbox(astap_radius_subframe, from_=0.0, to=180.0, increment=0.5, textvariable=self.astap_search_radius_var, width=6, format="%.1f").pack(side=tk.LEFT)
+        ttk.Spinbox(
+            astap_radius_subframe,
+            from_=0.0,
+            to=180.0,
+            increment=0.5,
+            textvariable=self.astap_search_radius_var,
+            width=6,
+            format="%.2f",
+        ).pack(side=tk.LEFT)
 
 
         # --- MODIFICATION : Configuration Astrometry.net Local (ansvr) avec deux boutons ---

--- a/tests/test_astrometry_solver.py
+++ b/tests/test_astrometry_solver.py
@@ -51,6 +51,7 @@ def test_astap_command_uses_gui_parameters(tmp_path, monkeypatch):
     cmd = captured["cmd"]
     assert "-z" in cmd and cmd[cmd.index("-z") + 1] == "4"
     assert "-sens" in cmd and cmd[cmd.index("-sens") + 1] == "55"
+    assert "-r" in cmd and cmd[cmd.index("-r") + 1] == "3.00"
 
 
 def test_parse_wcs_with_nonstandard_keywords(tmp_path):

--- a/tests/test_mosaic_worker.py
+++ b/tests/test_mosaic_worker.py
@@ -328,6 +328,15 @@ def test_output_scale_warning_and_adjust(monkeypatch, caplog):
     import importlib
     importlib.reload(worker)
 
+    monkeypatch.setattr(worker, "REPROJECT_AVAILABLE", True)
+    monkeypatch.setattr(
+        worker,
+        "reproject_interp",
+        lambda input_data, output_projection, shape_out=None, order="bilinear", parallel=False: (input_data[0], np.ones(shape_out)),
+    )
+    monkeypatch.setattr(worker, "ZEMOSAIC_UTILS_AVAILABLE", True)
+    monkeypatch.setattr(worker, "ASTROMETRY_SOLVER_AVAILABLE", True)
+
     monkeypatch.setattr(worker, "CALC_GRID_OPTIMIZED_AVAILABLE", False)
 
     def dummy_focw(inputs, resolution, auto_rotate=True, projection='TAN', reference=None, frame='icrs'):


### PR DESCRIPTION
## Summary
- format ASTAP search radius to always send two decimals
- show two decimals in local solver spinbox
- adapt tests for the new formatting and patch mosaic worker test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436554ea70832f9f86bfa609ace7d6