### PR TITLE
Disable RA/DEC hints by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,14 +296,15 @@ zemosaic_worker.run_hierarchical_mosaic(
   omitted the solver uses `ASTAP_DEFAULT_SEARCH_RADIUS` (3.0 degrees)
 - `astap_downsample`: downsample factor used by ASTAP
 - `astap_sensitivity`: detection sensitivity percentage for ASTAP
-- `use_radec_hints`: include FITS RA/DEC as hints when solving with ASTAP
+- `use_radec_hints`: include FITS RA/DEC as hints when solving with ASTAP *(defaults to false; enable only if your FITS headers contain reliable coordinates)*
 - `local_ansvr_path`: path to a local `ansvr.cfg`
 - `api_key`: astrometry.net API key
 - `local_solver_preference`: preferred local solver (`astap` or `ansvr`)
 
 `use_radec_hints` controls whether ASTAP receives the RA/DEC coordinates from
-the FITS header. When disabled the solver performs a blind search centered only
-on the provided search radius.
+the FITS header. This option is **disabled by default** and should only be
+enabled when those header values are trustworthy. When disabled the solver
+performs a blind search centered only on the provided search radius.
 
 ---
 

--- a/seestar/alignment/astrometry_solver.py
+++ b/seestar/alignment/astrometry_solver.py
@@ -339,7 +339,7 @@ class AstrometrySolver:
         astap_downsample_val = settings.get('astap_downsample', 2)
         astap_sensitivity_val = settings.get('astap_sensitivity', 100)
         astap_timeout = settings.get('astap_timeout_sec', 120)
-        use_radec_hints = settings.get('use_radec_hints', True)
+        use_radec_hints = settings.get('use_radec_hints', False)
 
         ansvr_config_path = settings.get('local_ansvr_path', "")
         ansvr_timeout = settings.get('ansvr_timeout_sec', 120)
@@ -652,7 +652,7 @@ class AstrometrySolver:
         update_header_with_solution,
         astap_downsample=2,
         astap_sensitivity=100,
-        use_radec_hints=True,
+        use_radec_hints=False,
     ):
         self._log(f"Entering _try_solve_astap for {os.path.basename(image_path)}", "DEBUG")
         self._log(f"ASTAP: Début résolution pour {os.path.basename(image_path)}", "INFO")

--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -54,7 +54,7 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         print(f"DEBUG (LocalSolverSettingsWindow __init__): astap_search_radius_var initialisée à {self.astap_search_radius_var.get()}.") # DEBUG
 
         self.use_radec_hints_var = tk.BooleanVar(
-            value=getattr(self.parent_gui.settings, 'use_radec_hints', True)
+            value=getattr(self.parent_gui.settings, 'use_radec_hints', False)
         )
 
 

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -165,7 +165,11 @@ class SettingsManager:
             self.astap_data_dir = getattr(self, 'astap_data_dir', default_values_from_code.get('astap_data_dir', ''))
             self.astap_search_radius = getattr(self, 'astap_search_radius', default_values_from_code.get('astap_search_radius', 30.0))
             self.local_ansvr_path = getattr(self, 'local_ansvr_path', default_values_from_code.get('local_ansvr_path', ''))
-            self.use_radec_hints = getattr(gui_instance, 'use_radec_hints_var', tk.BooleanVar(value=default_values_from_code.get('use_radec_hints', True))).get()
+            self.use_radec_hints = getattr(
+                gui_instance,
+                'use_radec_hints_var',
+                tk.BooleanVar(value=default_values_from_code.get('use_radec_hints', False)),
+            ).get()
             
             print(f"DEBUG SM (update_from_ui V_SaveAsFloat32_1): Valeurs solveurs locaux (après lecture/conservation de self): " # Version Log
                   f"Pref='{self.local_solver_preference}', ASTAP Path='{self.astap_path}', ASTAP Radius={self.astap_search_radius}")
@@ -452,7 +456,7 @@ class SettingsManager:
         defaults_dict['astap_path'] = ""
         defaults_dict['astap_data_dir'] = ""
         defaults_dict['astap_search_radius'] = 3.0
-        defaults_dict['use_radec_hints'] = True
+        defaults_dict['use_radec_hints'] = False
         defaults_dict['local_ansvr_path'] = ""
         
         defaults_dict['mosaic_mode_active'] = False
@@ -859,7 +863,7 @@ class SettingsManager:
                 self.astap_data_dir = defaults_fallback['astap_data_dir']
             else:
                 self.astap_data_dir = current_astap_data_dir.strip()
-            self.use_radec_hints = bool(getattr(self, 'use_radec_hints', True))
+            self.use_radec_hints = bool(getattr(self, 'use_radec_hints', False))
             try:
                 current_astap_radius = float(getattr(self, 'astap_search_radius', defaults_fallback['astap_search_radius']))
                 if not (0.0 <= current_astap_radius <= 180.0): 
@@ -1005,7 +1009,7 @@ class SettingsManager:
             'astap_path': str(getattr(self, 'astap_path', "")),
             'astap_data_dir': str(getattr(self, 'astap_data_dir', "")),
             'astap_search_radius': float(getattr(self, 'astap_search_radius', 30.0)), # Maintenu comme avant
-            'use_radec_hints': bool(getattr(self, 'use_radec_hints', True)),
+            'use_radec_hints': bool(getattr(self, 'use_radec_hints', False)),
             'local_ansvr_path': str(getattr(self, 'local_ansvr_path', "")),
         }
 


### PR DESCRIPTION
## Summary
- default `use_radec_hints` to false in settings
- initialize LocalSolverSettingsWindow with the updated setting
- make astrometry solver use the new default
- document the new default in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684382d59b20832fab0fffe3a0c7de0a