### PR TITLE
Honor use_radec_hints when re-solving cropped tiles

### DIFF
--- a/tests/test_mosaic_worker.py
+++ b/tests/test_mosaic_worker.py
@@ -177,7 +177,7 @@ def test_resolve_after_crop(monkeypatch, tmp_path):
         apply_crop=True,
         crop_percent=10.0,
         re_solve_cropped_tiles=True,
-        solver_settings={},
+        solver_settings={"use_radec_hints": True},
         solver_instance=dummy_solver,
     )
 
@@ -185,6 +185,88 @@ def test_resolve_after_crop(monkeypatch, tmp_path):
     assert dummy_solver.called
     assert pytest.approx(dummy_solver.ra, abs=1e-6) == expected_ra
     assert pytest.approx(dummy_solver.dec, abs=1e-6) == expected_dec
+    assert captured.get("pixel_shapes") == [(80, 80)]
+
+
+def test_resolve_after_crop_no_hints(monkeypatch, tmp_path):
+    importlib.reload(worker)
+
+    monkeypatch.setattr(worker, "REPROJECT_AVAILABLE", True)
+    monkeypatch.setattr(
+        worker,
+        "reproject_interp",
+        lambda input_data, output_projection, shape_out=None, order="bilinear", parallel=False: (input_data[0], np.ones(shape_out)),
+    )
+    monkeypatch.setattr(
+        worker,
+        "reproject_and_coadd",
+        lambda input_data, output_projection, shape_out, reproject_function=None, combine_function="mean", match_background=True, **kwargs: (np.zeros(shape_out, dtype=np.float32), np.zeros(shape_out, dtype=np.float32)),
+    )
+    monkeypatch.setattr(worker, "ZEMOSAIC_UTILS_AVAILABLE", True)
+    monkeypatch.setattr(worker, "ASTROMETRY_SOLVER_AVAILABLE", True)
+
+    class DummyZU:
+        @staticmethod
+        def crop_image_and_wcs(image_data, wcs_obj, crop_fraction, progress_callback=None):
+            h, w = image_data.shape[:2]
+            dh = int(h * crop_fraction)
+            dw = int(w * crop_fraction)
+            cropped = image_data[dh:h-dh, dw:w-dw, :]
+            new_wcs = wcs_obj.copy()
+            new_wcs.pixel_shape = (cropped.shape[1], cropped.shape[0])
+            return cropped, new_wcs
+
+    monkeypatch.setattr(worker, "zemosaic_utils", DummyZU)
+
+    data = np.ones((1, 100, 100), dtype=np.float32)
+    fits_path = tmp_path / "tile.fits"
+    from astropy.io import fits
+    fits.writeto(fits_path, data, overwrite=True)
+
+    wcs_in = make_wcs(0, 0, shape=(100, 100))
+
+    class DummySolver:
+        def __init__(self):
+            self.called = False
+            self.ra = None
+            self.dec = None
+
+        def solve(self, image_path, fits_header, settings, update_header_with_solution=True):
+            self.called = True
+            self.ra = fits_header.get("RA")
+            self.dec = fits_header.get("DEC")
+            return make_wcs(1, 1, shape=(80, 80))
+
+    solver = DummySolver()
+
+    captured = {}
+
+    def dummy_reproject_and_coadd(input_data, output_projection, shape_out, reproject_function=None, combine_function="mean", match_background=True, **kwargs):
+        captured["pixel_shapes"] = [w.pixel_shape for _, w in input_data]
+        return np.zeros(shape_out, dtype=np.float32), np.zeros(shape_out, dtype=np.float32)
+
+    monkeypatch.setattr(worker, "reproject_and_coadd", dummy_reproject_and_coadd)
+
+    final_wcs = make_wcs(0, 0, shape=(80, 80))
+    final_shape = (80, 80)
+
+    worker.assemble_final_mosaic_with_reproject_coadd(
+        [(str(fits_path), wcs_in)],
+        final_wcs,
+        final_shape,
+        progress_callback=None,
+        n_channels=1,
+        match_bg=False,
+        apply_crop=True,
+        crop_percent=10.0,
+        re_solve_cropped_tiles=True,
+        solver_settings={},
+        solver_instance=solver,
+    )
+
+    assert solver.called
+    assert solver.ra is None
+    assert solver.dec is None
     assert captured.get("pixel_shapes") == [(80, 80)]
 
 
@@ -265,7 +347,7 @@ def test_solver_header_values_no_wcs(monkeypatch, tmp_path):
         apply_crop=True,
         crop_percent=10.0,
         re_solve_cropped_tiles=True,
-        solver_settings={},
+        solver_settings={"use_radec_hints": True},
         solver_instance=solver,
     )
 

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -1454,18 +1454,21 @@ def assemble_final_mosaic_with_reproject_coadd(
                                     lvl="DEBUG_DETAIL",
                                 )
 
-                                try:
-                                    center = (
-                                        data_to_use_for_assembly.shape[1] / 2,
-                                        data_to_use_for_assembly.shape[0] / 2,
-                                    )
-                                    ra_hint, dec_hint = wcs_to_use_for_assembly.wcs_pix2world(
-                                        [[center[0], center[1]]], 0
-                                    )[0]
-                                except Exception:
-                                    ra_hint, dec_hint = None, None
+                                use_radec_hints = bool((solver_settings or {}).get("use_radec_hints", False))
+                                ra_hint, dec_hint = None, None
+                                if use_radec_hints:
+                                    try:
+                                        center = (
+                                            data_to_use_for_assembly.shape[1] / 2,
+                                            data_to_use_for_assembly.shape[0] / 2,
+                                        )
+                                        ra_hint, dec_hint = wcs_to_use_for_assembly.wcs_pix2world(
+                                            [[center[0], center[1]]], 0
+                                        )[0]
+                                    except Exception:
+                                        ra_hint, dec_hint = None, None
 
-                                if ra_hint is not None and dec_hint is not None:
+                                if use_radec_hints and ra_hint is not None and dec_hint is not None:
                                     header_for_solver['CRVAL1'] = ra_hint
                                     header_for_solver['CRVAL2'] = dec_hint
                                     header_for_solver['RA'] = ra_hint


### PR DESCRIPTION
## Summary
- allow specifying `use_radec_hints` when re-solving cropped tiles
- test solver RA/DEC hints pass through only when enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684388c6218c832f9256591e7b962dea