### PR TITLE
Add use_radec_hints solver option

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ solver_settings = {
     "astap_search_radius": 3.0,
     "astap_downsample": 2,
     "astap_sensitivity": 100,
+    "use_radec_hints": False,
     "local_ansvr_path": "/path/to/ansvr.cfg",
     "api_key": "your_key",
     "local_solver_preference": "astap",

--- a/zemosaic/zemosaic_astrometry.py
+++ b/zemosaic/zemosaic_astrometry.py
@@ -17,6 +17,7 @@ def solve_with_astap(
     search_radius_deg: float | None = None,
     downsample_factor: int | None = None,
     sensitivity: int | None = None,
+    use_radec_hints: bool = False,
     timeout_sec: int = 180,
     update_original_header_in_place: bool = True,
     progress_callback=None,
@@ -36,6 +37,7 @@ def solve_with_astap(
         else ASTAP_DEFAULT_SEARCH_RADIUS,
         "astap_downsample": downsample_factor,
         "astap_sensitivity": sensitivity,
+        "use_radec_hints": use_radec_hints,
         "astap_timeout_sec": timeout_sec,
         # Defaults for other solver parameters
         "local_ansvr_path": None,
@@ -44,7 +46,6 @@ def solve_with_astap(
         "astrometry_net_timeout_sec": 300,
         "scale_est_arcsec_per_pix": None,
         "scale_tolerance_percent": 20,
-        "use_radec_hints": False,
     }
 
     return solver_instance.solve(

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -713,6 +713,7 @@ def get_wcs_and_pretreat_raw_file(file_path: str, solver_settings: dict,
                     search_radius_deg=solver_settings.get('astap_search_radius'),
                     downsample_factor=solver_settings.get('astap_downsample'),
                     sensitivity=solver_settings.get('astap_sensitivity'),
+                    use_radec_hints=solver_settings.get('use_radec_hints'),
                     timeout_sec=solver_settings.get('astap_timeout_sec', 180),
                     update_original_header_in_place=True,
                     progress_callback=progress_callback,
@@ -1868,6 +1869,7 @@ def run_hierarchical_mosaic(
             solver_settings.setdefault('ansvr_timeout_sec', 120)
             solver_settings.setdefault('astap_timeout_sec', 180)
             solver_settings.setdefault('astrometry_net_timeout_sec', 300)
+            solver_settings.setdefault('use_radec_hints', False)
         except Exception as e_solver_inst:
             pcb("run_warn_solver_init_failed", prog=None, lvl="WARN", error=str(e_solver_inst))
             astrometry_solver = None


### PR DESCRIPTION
## Summary
- expose `use_radec_hints` flag in `solve_with_astap`
- forward the option from `zemosaic_worker`
- show `use_radec_hints` in example solver settings

## Testing
- `pip install numpy astropy Pillow scikit-image pytest -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843efea76b0832f8d50d023dd59072e