### PR TITLE
Document test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,20 @@ pip install -r requirements.txt
 
 # packages needed for the unit tests
 pip install pytest numpy astropy reproject
-# or, if provided, use the dedicated file
-pip install -r tests/requirements.txt
+# or install them using the dedicated file
+pip install -r requirements-test.txt
 ```
+
+### Test Dependencies
+
+The unit tests rely on a few additional packages:
+
+- `pytest`
+- `numpy`
+- `astropy`
+- `reproject`
+
+They can be installed individually or via the `requirements-test.txt` file.
 
 **Run the tests**
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest
+numpy
+astropy
+reproject


### PR DESCRIPTION
## Summary
- list the extra packages required for the tests
- mention `requirements-test.txt`
- provide the optional requirements file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843f4fd84f4832f91eb208411782f77