### PR TITLE
Default RA/DEC hints enabled in mosaic worker

### DIFF
--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -1869,7 +1869,7 @@ def run_hierarchical_mosaic(
             solver_settings.setdefault('ansvr_timeout_sec', 120)
             solver_settings.setdefault('astap_timeout_sec', 180)
             solver_settings.setdefault('astrometry_net_timeout_sec', 300)
-            solver_settings.setdefault('use_radec_hints', False)
+            solver_settings.setdefault('use_radec_hints', True)
         except Exception as e_solver_inst:
             pcb("run_warn_solver_init_failed", prog=None, lvl="WARN", error=str(e_solver_inst))
             astrometry_solver = None


### PR DESCRIPTION
## Summary
- default to using RA/DEC hints when creating solver settings in the mosaic worker
- tests remain passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f512224c832f9b4382e361e449f6