### PR TITLE
Add missing mosaic translations

### DIFF
--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -292,6 +292,7 @@ EN_TRANSLATIONS = {
     'Mosaic...': "Mosaic...",
     'mosaic_settings_title': "Mosaic Options",
     'mosaic_activation_frame': "Activation",
+    'mosaic_activation_frame_title': "Activation",
     'mosaic_activate_label': "Enable Mosaic Processing Mode",
     'cancel': "Cancel",
     'ok': "OK",
@@ -322,12 +323,14 @@ EN_TRANSLATIONS = {
 
     'mosaic_drizzle_fillval_label': "Fill Value:", # Nouveau
     'mosaic_drizzle_wht_thresh_label': "Low WHT Mask (%):", # Nouveau (différent du Drizzle global pour être sûr)
+    'mosaic_scale_label': "Scale Factor:",
     'mosaic_validation_orb_range': "ORB Features must be between {min_orb} and {max_orb}.",
     'mosaic_validation_matches_range': "Min Absolute Matches must be between {min_matches} and {max_matches}.",
     'mosaic_validation_inliers_range': "Min RANSAC Inliers must be between {min_inliers} and {max_inliers}.",
     'mosaic_validation_ransac_thresh_range': "RANSAC Threshold must be between {min_thresh:.1f} and {max_thresh:.1f}.",
     'mosaic_error_reading_spinbox': "Error reading Spinbox value: {error_details}",
     'mosaic_error_converting_spinbox': "Error converting Spinbox value: {error_details}",
+    'msw_api_key_missing_warning': "Astrometry.net API Key is missing. Plate solving for mosaic (anchor or panels) might fail if local solvers are not configured or also fail. Continue anyway?",
     
     # --- LocalSolverSettingsWindow ---   
     'local_solver_button_text': "Solver Config",

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -326,6 +326,7 @@ FR_TRANSLATIONS = {
     'Mosaic...': "Mosaïque...",
     'mosaic_settings_title': "Options Mosaïque",
     'mosaic_activation_frame': "Activation",
+    'mosaic_activation_frame_title': "Activation",
     'mosaic_activate_label': "Activer le mode de traitement Mosaïque",
     'cancel': "Annuler",
     'ok': "OK",
@@ -357,6 +358,7 @@ FR_TRANSLATIONS = {
 
     'mosaic_drizzle_fillval_label': "Val. Remplissage :", # Nouveau
     'mosaic_drizzle_wht_thresh_label': "Masque Bas WHT (%) :", # Nouveau
+    'mosaic_scale_label': "Facteur d’échelle :",
 
     'mosaic_validation_orb_range': "Points ORB doit être entre {min_orb} et {max_orb}.",
     'mosaic_validation_matches_range': "Corresp. Abs. Min doit être entre {min_matches} et {max_matches}.",
@@ -364,6 +366,7 @@ FR_TRANSLATIONS = {
     'mosaic_validation_ransac_thresh_range': "Seuil RANSAC doit être entre {min_thresh:.1f} et {max_thresh:.1f}.",
     'mosaic_error_reading_spinbox': "Erreur de lecture d'une valeur de Spinbox : {error_details}",
     'mosaic_error_converting_spinbox': "Erreur de conversion d'une valeur de Spinbox : {error_details}",
+    'msw_api_key_missing_warning': "La clé API Astrometry.net est manquante. Le plate solving pour la mosaïque (ancrage ou panneaux) pourrait échouer si les solveurs locaux ne sont pas configurés ou échouent aussi. Continuer malgré tout ?",
    
     # --- LocalSolverSettingsWindow ---   
     'local_solver_button_text': "Config Solveur",


### PR DESCRIPTION
## Summary
- define `mosaic_activation_frame_title` and `mosaic_scale_label` in translations
- add `msw_api_key_missing_warning` so all mosaic GUI keys are translated

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441793e360832fb37b221e0bbc6765