### PR TITLE
Sync ZeMosaic language with Seestar

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -3201,6 +3201,11 @@ class SeestarStackerGUI:
                 env["ZEMOSAIC_ASTAP_SEARCH_RADIUS"] = str(radius_val)
             except Exception:
                 pass
+            # Propagate current UI language to ZeMosaic
+            try:
+                env["ZEMOSAIC_LANGUAGE"] = self.language_var.get()
+            except Exception:
+                env["ZEMOSAIC_LANGUAGE"] = self.settings.language
 
             # Directly execute the run_zemosaic.py script located in the
             # ``zemosaic`` directory of the project. Using the explicit file

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -131,6 +131,10 @@ class ZeMosaicGUI:
         }
         logger.info("Effective solver settings: %s", effective_solver_config)
 
+        env_lang = os.environ.get("ZEMOSAIC_LANGUAGE")
+        if env_lang:
+            self.config["language"] = env_lang
+
         default_lang_from_config = self.config.get("language", 'en')
         if ZEMOSAIC_LOCALIZATION_AVAILABLE and ZeMosaicLocalization:
             self.localizer = ZeMosaicLocalization(language_code=default_lang_from_config)


### PR DESCRIPTION
## Summary
- pass current language to ZeMosaic when launching it from Seestar
- allow ZeMosaic to read `ZEMOSAIC_LANGUAGE` env var at startup

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684419e7b3bc832f90dfb507af748b9e