### PR TITLE
Fix localization import

### DIFF
--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -22,10 +22,16 @@ except ImportError:
 try:
     from .locales.zemosaic_localization import ZeMosaicLocalization
     ZEMOSAIC_LOCALIZATION_AVAILABLE = True
-except ImportError as e_loc:
-    ZEMOSAIC_LOCALIZATION_AVAILABLE = False
-    ZeMosaicLocalization = None # Factice
-    print(f"ERREUR (zemosaic_gui): Impossible d'importer 'ZeMosaicLocalization': {e_loc}")
+except ImportError:
+    try:
+        from zemosaic.locales.zemosaic_localization import ZeMosaicLocalization
+        ZEMOSAIC_LOCALIZATION_AVAILABLE = True
+    except ImportError as e_loc:
+        ZEMOSAIC_LOCALIZATION_AVAILABLE = False
+        ZeMosaicLocalization = None  # Factice
+        print(
+            f"ERREUR (zemosaic_gui): Impossible d'importer 'ZeMosaicLocalization': {e_loc}"
+        )
 
 # --- Configuration Import ---
 try:


### PR DESCRIPTION
## Summary
- fix fallback import for the localization module so translations load when running run_zemosaic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68441fbf092c832fa93c33b6e2b0df7d