### PR TITLE
Fix ZeMosaic imports by adding package init

### DIFF
--- a/zemosaic/__init__.py
+++ b/zemosaic/__init__.py
@@ -1,0 +1,3 @@
+"""ZeMosaic package initialization."""
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- ensure `zemosaic` is treated as a package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442725301c832fa08a30abd62182b7