### PR TITLE
Fix missing config attribute

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -275,6 +275,22 @@ class SeestarStackerGUI:
 
         self.logger.info("DEBUG (GUI __init__): Initialisation SeestarStackerGUI terminée.")
 
+    @property
+    def config(self):
+        """Alias de compatibilité pour l'ancien attribut ``config``.
+
+        Certains modules externes peuvent encore accéder à ``self.config`` en
+        supposant récupérer un dictionnaire de paramètres. Cette propriété
+        renvoie le ``__dict__`` de ``self.settings`` si disponible afin d'éviter
+        une erreur d'attribut manquant.
+        """
+        if hasattr(self, "settings"):
+            try:
+                return self.settings.__dict__
+            except Exception:
+                return {}
+        return {}
+
 
 
 


### PR DESCRIPTION
## Summary
- provide `config` property in `SeestarStackerGUI`

## Testing
- `python -m py_compile seestar/gui/main_window.py seestar/gui/local_solver_gui.py`
- `python - <<'PY'
from seestar.gui.main_window import SeestarStackerGUI
try:
    app=SeestarStackerGUI()
    print('config exists', isinstance(app.config, dict))
except Exception as e:
    print('error', e)
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684434352ac0832f88a5c515bde08897