### PR TITLE
Ensure config fallback for solver settings

### DIFF
--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -20,7 +20,13 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         """
         super().__init__(parent_gui.root)
         self.parent_gui = parent_gui
-        self.withdraw() # Cacher pendant la configuration
+        # Load fallback config if the parent GUI lacks one
+        if not hasattr(self.parent_gui, "config"):
+            try:
+                self.parent_gui.config = zemosaic_config.load_config()
+            except Exception:
+                self.parent_gui.config = {}
+        self.withdraw()  # Cacher pendant la configuration
 
         self.title(self.parent_gui.tr("local_solver_window_title", default="Local Astrometry Solvers Configuration"))
         self.transient(parent_gui.root)

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -68,6 +68,17 @@ except ImportError as e: logger.error(f"Import 'zemosaic_astrometry.py' échoué
 try: import zemosaic_align_stack; ZEMOSAIC_ALIGN_STACK_AVAILABLE = True; logger.info("Module 'zemosaic_align_stack' importé.")
 except ImportError as e: logger.error(f"Import 'zemosaic_align_stack.py' échoué: {e}.")
 
+# Flags used by the test suite to toggle optional features
+ASTROMETRY_SOLVER_AVAILABLE = ZEMOSAIC_ASTROMETRY_AVAILABLE
+CALC_GRID_OPTIMIZED_AVAILABLE = False
+
+def _calculate_final_mosaic_grid_optimized(panel_wcs_list, panel_shapes_hw_list,
+                                           drizzle_scale_factor: float = 1.0,
+                                           progress_callback: callable = None):
+    """Fallback optimized grid routine used in tests."""
+    return _calculate_final_mosaic_grid(panel_wcs_list, panel_shapes_hw_list,
+                                         drizzle_scale_factor, progress_callback)
+
 
 
 


### PR DESCRIPTION
## Summary
- load a fallback config in `LocalSolverSettingsWindow` when the parent GUI lacks one
- expose compatibility flags and stub `_calculate_final_mosaic_grid_optimized` for tests

## Testing
- `pytest -q` *(fails: calcgrid_error_reproject_unavailable, assemble_final_mosaic_with_reproject_coadd unexpected kwargs, missing prepare_tiles_and_calc_grid, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68443c7e3de0832fa1d8da6da9f1242a