### PR TITLE
Add solver_settings dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ python -m seestar.scripts.run_mosaic INPUT_DIR OUTPUT_DIR \
     --astap-data-dir /path/to/catalogs
 ```
 
-Solver options correspond to the `ZEMOSAIC_*` environment variables used by the GUI.
+Solver options correspond to the `ZEMOSAIC_*` environment variables used by the GUI. These values can be configured from the **Mosaic Options** window.
 When calling the worker from Python, gather them into a `solver_settings` dictionary:
 
 ```python

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -1121,6 +1121,17 @@ class ZeMosaicGUI:
         os.environ["ZEMOSAIC_LOCAL_ANSVR_PATH"] = astrometry_local_path_val
         os.environ["ZEMOSAIC_ASTROMETRY_API_KEY"] = astrometry_api_key_val
 
+        solver_settings = {
+            "local_solver_preference": solver_choice_val,
+            "local_ansvr_path": astrometry_local_path_val,
+            "api_key": astrometry_api_key_val,
+            "astap_path": astap_exe,
+            "astap_data_dir": astap_data,
+            "astap_search_radius": astap_radius_val,
+            "astap_downsample": astap_downsample_val,
+            "astap_sensitivity": astap_sensitivity_val,
+        }
+
         # 3. PARSING et VALIDATION des limites Winsor (inchangé)
         parsed_winsor_limits = (0.05, 0.05) 
         if stack_reject_algo == "winsorized_sigma_clip":
@@ -1145,10 +1156,11 @@ class ZeMosaicGUI:
         # ... (autres logs d'info) ...
 
         worker_args = (
-            input_dir, output_dir, astap_exe, astap_data, 
-            astap_radius_val, astap_downsample_val, astap_sensitivity_val, 
-            cluster_thresh_val, 
-            self._log_message, 
+            input_dir,
+            output_dir,
+            solver_settings,
+            cluster_thresh_val,
+            self._log_message,
             stack_norm_method,
             stack_weight_method,
             stack_reject_algo,

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -1100,11 +1100,7 @@ def assemble_final_mosaic_with_reproject_coadd(
 def run_hierarchical_mosaic(
     input_folder: str,
     output_folder: str,
-    astap_exe_path: str,
-    astap_data_dir_param: str,
-    astap_search_radius_config: float,
-    astap_downsample_config: int,
-    astap_sensitivity_config: int,
+    solver_settings: dict | None,
     cluster_threshold_config: float,
     progress_callback: callable,
     stack_norm_method: str,
@@ -1131,6 +1127,12 @@ def run_hierarchical_mosaic(
     """
     pcb = lambda msg_key, prog=None, lvl="INFO", **kwargs: _log_and_callback(msg_key, prog, lvl, callback=progress_callback, **kwargs)
     
+    solver_settings = solver_settings or {}
+    astap_exe_path = solver_settings.get("astap_path", zemosaic_config.get_astap_executable_path())
+    astap_data_dir_param = solver_settings.get("astap_data_dir", zemosaic_config.get_astap_data_directory_path())
+    astap_search_radius_config = solver_settings.get("astap_search_radius", zemosaic_config.get_astap_default_search_radius())
+    astap_downsample_config = solver_settings.get("astap_downsample", zemosaic_config.get_astap_default_downsample())
+    astap_sensitivity_config = solver_settings.get("astap_sensitivity", zemosaic_config.get_astap_default_sensitivity())
     def update_gui_eta(eta_seconds_total):
         if progress_callback and callable(progress_callback):
             eta_str = "--:--:--"


### PR DESCRIPTION
## Summary
- collect solver settings from GUI and build a dictionary
- pass solver_settings to the worker
- support dict argument in `run_hierarchical_mosaic`
- document new Mosaic Options for solver settings

## Testing
- `pip install -r requirements-test.txt`
- `pip install psutil`
- `pytest -q` *(fails: assemble_final_mosaic_with_reproject_coadd errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_6844550691b4832fbcb2ea20cfde7dc1