### PR TITLE
Fix zemosaic worker imports

### DIFF
--- a/zemosaic/zemosaic_config.py
+++ b/zemosaic/zemosaic_config.py
@@ -32,9 +32,6 @@ DEFAULT_CONFIG = {
     "apply_master_tile_crop": True,       # Désactivé par défaut
     "master_tile_crop_percent": 18.0,      # Pourcentage par côté si activé (ex: 10%)
     # --- FIN CLES POUR LE ROGNAGE ---
-    "solver_method": "astap",
-    "astrometry_local_path": "",
-    "astrometry_api_key": ""
 }
 
 def get_config_path():

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -60,6 +60,7 @@ except Exception as e_reproject_other_final: logger.critical(f"Erreur import 're
 zemosaic_utils, ZEMOSAIC_UTILS_AVAILABLE = None, False
 zemosaic_astrometry, ZEMOSAIC_ASTROMETRY_AVAILABLE = None, False
 zemosaic_align_stack, ZEMOSAIC_ALIGN_STACK_AVAILABLE = None, False
+zemosaic_config = None
 
 try: import zemosaic_utils; ZEMOSAIC_UTILS_AVAILABLE = True; logger.info("Module 'zemosaic_utils' importé.")
 except ImportError as e: logger.error(f"Import 'zemosaic_utils.py' échoué: {e}.")
@@ -67,6 +68,11 @@ try: import zemosaic_astrometry; ZEMOSAIC_ASTROMETRY_AVAILABLE = True; logger.in
 except ImportError as e: logger.error(f"Import 'zemosaic_astrometry.py' échoué: {e}.")
 try: import zemosaic_align_stack; ZEMOSAIC_ALIGN_STACK_AVAILABLE = True; logger.info("Module 'zemosaic_align_stack' importé.")
 except ImportError as e: logger.error(f"Import 'zemosaic_align_stack.py' échoué: {e}.")
+try:
+    import zemosaic_config
+    logger.info("Module 'zemosaic_config' importé.")
+except ImportError as e:
+    logger.error(f"Import 'zemosaic_config.py' échoué: {e}.")
 
 # Flags used by the test suite to toggle optional features
 ASTROMETRY_SOLVER_AVAILABLE = ZEMOSAIC_ASTROMETRY_AVAILABLE


### PR DESCRIPTION
## Summary
- remove duplicate astrometry settings from default config
- load `zemosaic_config` in the worker module using package import

## Testing
- `pytest tests/test_zemosaic_config.py::test_default_config_has_new_keys -q`
- `pytest tests/test_zemosaic_config.py::test_config_round_trip_preserves_new_keys -q`
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68444ebaa2d8832fbc9c230422a90c86