### PR TITLE
Fix local astrometry path browse

### DIFF
--- a/zemosaic/locales/en.json
+++ b/zemosaic/locales/en.json
@@ -39,6 +39,9 @@
     "astrometry_local_path_label": "Local Astrometry Path:",
     "browse_astrometry_local_path_button": "Browse...",
     "select_astrometry_local_title": "Select Local Astrometry Path",
+    "select_astrometry_exe_or_cfg_title": "Select solve-field Executable or .cfg (Cancel for Index Dir)",
+    "select_astrometry_index_dir_title": "Select Astrometry.net Index Directory",
+    "configuration_files": "Configuration Files",
 
 
     "config_warning_title": "Config Warning",

--- a/zemosaic/locales/fr.json
+++ b/zemosaic/locales/fr.json
@@ -40,6 +40,9 @@
     "astrometry_local_path_label": "Chemin Astrometry Local :",
     "browse_astrometry_local_path_button": "Parcourir...",
     "select_astrometry_local_title": "Sélectionner le Chemin Astrometry Local",
+    "select_astrometry_exe_or_cfg_title": "Sélectionner solve-field ou fichier .cfg (Annuler pour le Dossier d'Index)",
+    "select_astrometry_index_dir_title": "Sélectionner le Dossier d'Index Astrometry.net",
+    "configuration_files": "Fichiers de Configuration",
 
 
     "config_warning_title": "Avertissement Configuration",

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -861,9 +861,55 @@ class ZeMosaicGUI:
         if dir_path: self.astap_data_dir_var.set(dir_path)
 
     def _browse_astrometry_local_path(self):
-        dir_path = filedialog.askdirectory(title=self._tr("select_astrometry_local_title", "Select Local Astrometry Path"))
-        if dir_path:
-            self.astrometry_local_path_var.set(dir_path)
+        def _log_browser(msg, level="DEBUG"):
+            print(f"DEBUG (ZeMosaicGUI _browse_astrometry_local_path) [{level}]: {msg}")
+
+        initial_dir = ""
+        current_path = self.astrometry_local_path_var.get()
+
+        if current_path:
+            if os.path.isfile(current_path):
+                initial_dir = os.path.dirname(current_path)
+            elif os.path.isdir(current_path):
+                initial_dir = current_path
+
+        if not initial_dir:
+            initial_dir = os.path.expanduser("~")
+
+        _log_browser(f"Opening file dialog (initialdir: {initial_dir})")
+        filepath_selected = filedialog.askopenfilename(
+            title=self._tr(
+                "select_astrometry_exe_or_cfg_title",
+                "Select solve-field Executable or .cfg (Cancel for Index Dir)",
+            ),
+            initialdir=initial_dir,
+            filetypes=[
+                (self._tr("configuration_files", "Configuration Files"), "*.cfg"),
+                (
+                    self._tr("executable_files", "Executable Files"),
+                    "*.*" if os.name != "nt" else "*.exe",
+                ),
+                (self._tr("all_files", "All Files"), "*.*"),
+            ],
+        )
+
+        if not filepath_selected:
+            _log_browser("No file selected. Opening directory dialog.")
+            dirpath_selected = filedialog.askdirectory(
+                title=self._tr(
+                    "select_astrometry_index_dir_title",
+                    "Select Astrometry.net Index Directory",
+                ),
+                initialdir=initial_dir,
+            )
+            if dirpath_selected:
+                _log_browser(f"Index directory selected: {dirpath_selected}")
+                self.astrometry_local_path_var.set(dirpath_selected)
+            else:
+                _log_browser("No index directory selected either.")
+        else:
+            _log_browser(f"File selected: {filepath_selected}")
+            self.astrometry_local_path_var.set(filepath_selected)
 
 
 


### PR DESCRIPTION
## Summary
- allow selecting config/executable or index directory for local astrometry solver
- add translation strings for new dialogs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'reproject')*

------
https://chatgpt.com/codex/tasks/task_e_684462597d28832fa0566dee2d7041d5