### PR TITLE
Implement fallback to Astrometry solve methods

### DIFF
--- a/zemosaic/zemosaic_config.py
+++ b/zemosaic/zemosaic_config.py
@@ -170,3 +170,11 @@ def get_astap_default_downsample():
 def get_astap_default_sensitivity():
     config = load_config()
     return config.get("astap_default_sensitivity", DEFAULT_CONFIG["astap_default_sensitivity"])
+
+
+def get_astrometry_local_path() -> str:
+    return load_config().get("astrometry_local_path", "")
+
+
+def get_astrometry_api_key() -> str:
+    return load_config().get("astrometry_api_key", "")


### PR DESCRIPTION
## Summary
- add simple wrappers around `AstrometrySolver` for local and web solving
- expose astrometry paths in config helpers
- attempt local ansvr then web solve after ASTAP failure
- store solver settings globally for worker threads
- handle missing `find_optimal_celestial_wcs` with an optimized fallback

## Testing
- `pip install -r requirements-test.txt`
- `pip install psutil`
- `pytest -q` *(fails: assemble_final_mosaic_with_reproject_coadd missing kwargs and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68446b9b0a84832fb1dffb4733cf444a