### PR TITLE
Fix solver method key

### DIFF
--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -1179,7 +1179,7 @@ class ZeMosaicGUI:
         os.environ["ZEMOSAIC_ASTROMETRY_API_KEY"] = astrometry_api_key_val
 
         solver_settings = {
-            "local_solver_preference": solver_choice_val,
+            "solver_method": solver_choice_val.lower(),  # "astap" ou "astrometry"
             "local_ansvr_path": astrometry_local_path_val,
             "api_key": astrometry_api_key_val,
             "astap_path": astap_exe,

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -352,6 +352,11 @@ def get_wcs_and_pretreat_raw_file(file_path: str, astap_exe_path: str, astap_dat
     _pcb_local(f"GetWCS_Pretreat: Début pour '{filename}'.", lvl="DEBUG_DETAIL") # Niveau DEBUG_DETAIL pour être moins verbeux
 
     solver_settings = GLOBAL_SOLVER_SETTINGS
+    if "solver_method" not in solver_settings and \
+       "local_solver_preference" in solver_settings:
+        solver_settings["solver_method"] = str(
+            solver_settings["local_solver_preference"]
+        ).lower()
     solver_method = solver_settings.get(
         "solver_method",
         zemosaic_config.get_solver_method()


### PR DESCRIPTION
## Summary
- unify solver preference key to `solver_method`
- migrate old `local_solver_preference` value when not present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zemosaic_utils' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68448c334468832faac8c8e1b5d8ae33