### PR TITLE
Restore local solver configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,11 @@ zemosaic_worker.run_hierarchical_mosaic(
 - `astap_sensitivity`: detection sensitivity percentage for ASTAP
 - `use_radec_hints`: include FITS RA/DEC as hints when solving with ASTAP *(defaults to false; enable only if your FITS headers contain reliable coordinates)*
 - `local_ansvr_path`: path to a local `ansvr.cfg`
+- `ansvr_host_port`: host and port for a running ansvr instance (default `127.0.0.1:8080`)
+- `astrometry_solve_field_dir`: directory containing the `solve-field` executable
 - `api_key`: astrometry.net API key
 - `local_solver_preference`: preferred local solver (`astap` or `ansvr`)
+- `enable_reprojection_between_batches`: when true, reproject each batch using the previous batch's WCS
 
 `use_radec_hints` controls whether ASTAP receives the RA/DEC coordinates from
 the FITS header. This option is **disabled by default** and should only be

--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -73,11 +73,28 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         self.cluster_threshold_var = tk.DoubleVar(
             value=self.parent_gui.config.get('cluster_panel_threshold', 0.5)
         )
+        self.astrometry_solve_field_dir_var = tk.StringVar(
+            value=getattr(self.parent_gui.settings, "astrometry_solve_field_dir", "")
+        )
+
 
 
         self.local_ansvr_path_var = tk.StringVar(
             value=getattr(self.parent_gui.settings, 'local_ansvr_path', "")
         )
+
+        self.ansvr_host_port_var = tk.StringVar(
+            value=getattr(self.parent_gui.settings, 'ansvr_host_port', '127.0.0.1:8080')
+        )
+
+        self.reproject_batches_var = tk.BooleanVar(
+            value=getattr(
+                self.parent_gui.settings, 'enable_reprojection_between_batches', False
+            )
+        )
+
+        self.reproject_batches_var.trace_add('write', lambda *args: self._update_warning())
+        self.local_solver_choice_var.trace_add('write', lambda *args: self._update_warning())
 
         # Construction de l'interface utilisateur
         self._build_ui()
@@ -119,11 +136,14 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         # État par défaut des sections
         astap_state = tk.DISABLED
         ansvr_state = tk.DISABLED
+        astrometry_state = tk.DISABLED
 
         if choice == "astap":
             astap_state = tk.NORMAL
         elif choice == "ansvr":
             ansvr_state = tk.NORMAL
+        elif choice == "astrometry":
+            astrometry_state = tk.NORMAL
         # Si "none", les deux restent DISABLED
 
         # Activer/Désactiver les widgets dans le cadre ASTAP
@@ -135,8 +155,16 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         if hasattr(self, 'ansvr_frame') and self.ansvr_frame.winfo_exists():
             for widget in self.ansvr_frame.winfo_children():
                 self._set_widget_state_recursive(widget, ansvr_state)
+
+        # Activer/Désactiver les widgets dans le cadre Astrometry
+        if hasattr(self, 'astrometry_frame') and self.astrometry_frame.winfo_exists():
+            for widget in self.astrometry_frame.winfo_children():
+                self._set_widget_state_recursive(widget, astrometry_state)
         
-        print(f"DEBUG (LocalSolverSettingsWindow _on_solver_choice_change): États des cadres mis à jour - ASTAP: {astap_state}, Ansvr: {ansvr_state}") # DEBUG
+        print(
+            f"DEBUG (LocalSolverSettingsWindow _on_solver_choice_change): États des cadres mis à jour - ASTAP: {astap_state}, Ansvr: {ansvr_state}"
+        )  # DEBUG
+        self._update_warning()
 
     def _set_widget_state_recursive(self, widget, state):
         """
@@ -152,6 +180,20 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         if hasattr(widget, 'winfo_children'):
             for child in widget.winfo_children():
                 self._set_widget_state_recursive(child, state)
+
+    def _update_warning(self, *args):
+        show = False
+        choice = self.local_solver_choice_var.get()
+        if self.reproject_batches_var.get():
+            if choice == 'astap' and not self.astap_path_var.get().strip():
+                show = True
+            elif choice == 'ansvr' and not self.ansvr_host_port_var.get().strip():
+                show = True
+            elif choice == 'astrometry' and not self.astrometry_solve_field_dir_var.get().strip():
+                show = True
+        self.warning_label.configure(
+            text='⚠️ Aucun solveur local configuré' if show else ''
+        )
 
 ####################################################################################################################################################
 
@@ -169,26 +211,145 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         main_frame = ttk.Frame(self, padding="10")
         main_frame.pack(expand=True, fill=tk.BOTH)
 
-        info_label = ttk.Label(
+        solver_choice_frame = ttk.LabelFrame(
             main_frame,
-            text=self.parent_gui.tr("solver_settings_moved", default="Astrometry solver settings are now available in Mosaic Options."),
-            justify=tk.LEFT,
-            wraplength=400,
+            text=self.parent_gui.tr(
+                "local_solver_choice_frame_title", default="Solver"
+            ),
+            padding="10",
         )
-        info_label.pack(pady=10, padx=5)
+        solver_choice_frame.pack(fill=tk.X, pady=(0, 10))
 
-        # --- Boutons OK / Annuler (inchangés) ---
+        ttk.Radiobutton(
+            solver_choice_frame,
+            text="ASTAP",
+            variable=self.local_solver_choice_var,
+            value="astap",
+            command=self._on_solver_choice_change,
+        ).pack(anchor=tk.W, pady=2)
+
+        ttk.Radiobutton(
+            solver_choice_frame,
+            text="Astrometry.net",
+            variable=self.local_solver_choice_var,
+            value="astrometry",
+            command=self._on_solver_choice_change,
+        ).pack(anchor=tk.W, pady=2)
+
+        ttk.Radiobutton(
+            solver_choice_frame,
+            text="Ansvr",
+            variable=self.local_solver_choice_var,
+            value="ansvr",
+            command=self._on_solver_choice_change,
+        ).pack(anchor=tk.W, pady=2)
+
+        self.astap_frame = ttk.LabelFrame(
+            main_frame,
+            text="ASTAP",
+            padding="10",
+        )
+        self.astap_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        astap_path_sub = ttk.Frame(self.astap_frame)
+        astap_path_sub.pack(fill=tk.X, pady=(5, 2))
+        ttk.Label(astap_path_sub, text="Executable:").pack(side=tk.LEFT)
+        ttk.Entry(astap_path_sub, textvariable=self.astap_path_var).pack(
+            side=tk.LEFT, fill=tk.X, expand=True, padx=(5, 0)
+        )
+        ttk.Button(
+            astap_path_sub,
+            text=self.parent_gui.tr("browse", default="Browse..."),
+            command=self._browse_astap_path,
+            width=12,
+        ).pack(side=tk.RIGHT, padx=(5, 0))
+
+        astap_data_sub = ttk.Frame(self.astap_frame)
+        astap_data_sub.pack(fill=tk.X, pady=(2, 5))
+        ttk.Label(astap_data_sub, text="Data Dir:").pack(side=tk.LEFT)
+        ttk.Entry(astap_data_sub, textvariable=self.astap_data_dir_var).pack(
+            side=tk.LEFT, fill=tk.X, expand=True, padx=(5, 0)
+        )
+        ttk.Button(
+            astap_data_sub,
+            text=self.parent_gui.tr("browse", default="Browse..."),
+            command=self._browse_astap_data_dir,
+            width=12,
+        ).pack(side=tk.RIGHT, padx=(5, 0))
+
+        self.astrometry_frame = ttk.LabelFrame(
+            main_frame,
+            text="Astrometry.net",
+            padding="10",
+        )
+        self.astrometry_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        api_key_sub = ttk.Frame(self.astrometry_frame)
+        api_key_sub.pack(fill=tk.X, pady=(5, 2))
+        ttk.Label(api_key_sub, text="API Key:").pack(side=tk.LEFT)
+        ttk.Entry(api_key_sub, textvariable=self.parent_gui.astrometry_api_key_var, show="*").pack(
+            side=tk.LEFT, fill=tk.X, expand=True, padx=(5, 0)
+        )
+
+        astrometry_dir_sub = ttk.Frame(self.astrometry_frame)
+        astrometry_dir_sub.pack(fill=tk.X, pady=(2, 5))
+        ttk.Label(astrometry_dir_sub, text="solve-field Dir:").pack(side=tk.LEFT)
+        ttk.Entry(astrometry_dir_sub, textvariable=self.astrometry_solve_field_dir_var).pack(
+            side=tk.LEFT, fill=tk.X, expand=True, padx=(5, 0)
+        )
+        ttk.Button(
+            astrometry_dir_sub,
+            text=self.parent_gui.tr("browse", default="Browse..."),
+            command=self._browse_astrometry_dir,
+            width=12,
+        ).pack(side=tk.RIGHT, padx=(5, 0))
+
+        self.ansvr_frame = ttk.LabelFrame(
+            main_frame,
+            text="Ansvr",
+            padding="10",
+        )
+        self.ansvr_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        ansvr_host_sub = ttk.Frame(self.ansvr_frame)
+        ansvr_host_sub.pack(fill=tk.X, pady=(5, 2))
+        ttk.Label(ansvr_host_sub, text="Host:Port:").pack(side=tk.LEFT)
+        ttk.Entry(ansvr_host_sub, textvariable=self.ansvr_host_port_var, width=15).pack(
+            side=tk.LEFT, padx=(5, 0)
+        )
+
+        ttk.Checkbutton(
+            main_frame,
+            text=self.parent_gui.tr(
+                "reproject_batches_label",
+                default="Activer la reprojection entre batchs (nécessite WCS)",
+            ),
+            variable=self.reproject_batches_var,
+        ).pack(anchor=tk.W, pady=(10, 0))
+
+        self.warning_label = ttk.Label(
+            main_frame,
+            foreground="red",
+        )
+        self.warning_label.pack(anchor=tk.W)
+
+        self._update_warning()
+
         button_frame = ttk.Frame(main_frame, padding="5")
         button_frame.pack(fill=tk.X, side=tk.BOTTOM, pady=(10, 0))
-        # ... (boutons OK et Annuler comme avant) ...
-        cancel_button = ttk.Button(button_frame,
-                                   text=self.parent_gui.tr("cancel", default="Cancel"),
-                                   command=self._on_cancel)
+        cancel_button = ttk.Button(
+            button_frame,
+            text=self.parent_gui.tr("cancel", default="Cancel"),
+            command=self._on_cancel,
+        )
         cancel_button.pack(side=tk.RIGHT, padx=(5, 0))
-        ok_button = ttk.Button(button_frame,
-                                    text=self.parent_gui.tr("ok", default="OK"),
-                                    command=self._on_ok)
+        ok_button = ttk.Button(
+            button_frame,
+            text=self.parent_gui.tr("ok", default="OK"),
+            command=self._on_ok,
+        )
         ok_button.pack(side=tk.RIGHT)
+
 
 
 
@@ -223,16 +384,30 @@ class LocalSolverSettingsWindow(tk.Toplevel):
     def _browse_astap_data_dir(self):
         initial_dir = self.astap_data_dir_var.get()
         if not initial_dir or not os.path.isdir(initial_dir):
-            initial_dir = os.path.expanduser("~") 
+            initial_dir = os.path.expanduser("~")
 
         dirpath = filedialog.askdirectory(
             title=self.parent_gui.tr("select_astap_data_dir_title", default="Select ASTAP Star Index Data Directory"),
             initialdir=initial_dir,
             parent=self 
         )
-        if dirpath: 
+        if dirpath:
             self.astap_data_dir_var.set(dirpath)
             print(f"DEBUG (LocalSolverSettingsWindow): Répertoire données ASTAP sélectionné: {dirpath}")
+
+    def _browse_astrometry_dir(self):
+        initial_dir = self.astrometry_solve_field_dir_var.get()
+        if not initial_dir or not os.path.isdir(initial_dir):
+            initial_dir = os.path.expanduser("~")
+
+        dirpath = filedialog.askdirectory(
+            title=self.parent_gui.tr("select_astrometry_exec_dir_title", default="Select solve-field Directory"),
+            initialdir=initial_dir,
+            parent=self,
+        )
+        if dirpath:
+            self.astrometry_solve_field_dir_var.set(dirpath)
+            print(f"DEBUG (LocalSolverSettingsWindow): Répertoire solve-field sélectionné: {dirpath}")
 
 
 
@@ -412,6 +587,9 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         astap_sensitivity = self.astap_sensitivity_var.get()
         cluster_threshold = self.cluster_threshold_var.get()
         local_ansvr_path = self.local_ansvr_path_var.get().strip()
+        ansvr_host_port = self.ansvr_host_port_var.get().strip()
+        reproject_batches = self.reproject_batches_var.get()
+        astrometry_dir = self.astrometry_solve_field_dir_var.get().strip()
 
         # Valider que si un solveur est choisi, son chemin principal est rempli
         validation_ok = True
@@ -423,8 +601,13 @@ class LocalSolverSettingsWindow(tk.Toplevel):
 
 
         elif solver_choice == "ansvr" and not local_ansvr_path:
-            messagebox.showerror(self.parent_gui.tr("error"), 
+            messagebox.showerror(self.parent_gui.tr("error"),
                                  self.parent_gui.tr("ansvr_path_required_error", default="Astrometry.net Local is selected, but the path/config is missing."),
+                                 parent=self)
+            validation_ok = False
+        elif solver_choice == "astrometry" and not astrometry_dir:
+            messagebox.showerror(self.parent_gui.tr("error"),
+                                 self.parent_gui.tr("astrometry_path_required_error", default="Astrometry.net is selected, but the solve-field directory is missing."),
                                  parent=self)
             validation_ok = False
         
@@ -442,6 +625,9 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         self.parent_gui.settings.astap_data_dir = astap_data_dir
         setattr(self.parent_gui.settings, 'astap_search_radius', astap_radius)
         self.parent_gui.settings.local_ansvr_path = local_ansvr_path
+        self.parent_gui.settings.ansvr_host_port = ansvr_host_port
+        self.parent_gui.settings.enable_reprojection_between_batches = reproject_batches
+        self.parent_gui.settings.astrometry_solve_field_dir = astrometry_dir
         try:
             self.parent_gui.settings.astrometry_api_key = self.parent_gui.astrometry_api_key_var.get().strip()
         except Exception:
@@ -457,14 +643,17 @@ class LocalSolverSettingsWindow(tk.Toplevel):
             zemosaic_config.save_config(self.parent_gui.config)
         except Exception:
             pass
-        
+
         print(
-            f"  LocalSolverSettingsWindow: Préférence Sauvegardée='{solver_choice}', ASTAP='{astap_path}', Data ASTAP='{astap_data_dir}', Radius ASTAP={astap_radius}, Down={astap_downsample}, Sens={astap_sensitivity}, Cluster={cluster_threshold}, Ansvr Local='{local_ansvr_path}'"
+            f"  LocalSolverSettingsWindow: Préférence Sauvegardée='{solver_choice}', ASTAP='{astap_path}', Data ASTAP='{astap_data_dir}', Radius ASTAP={astap_radius}, Down={astap_downsample}, Sens={astap_sensitivity}, Cluster={cluster_threshold}, Ansvr Local='{local_ansvr_path}', HostPort='{ansvr_host_port}', Astrometry Dir='{astrometry_dir}', ReprojBatches={reproject_batches}"
         )  # DEBUG
         print("  LocalSolverSettingsWindow: Paramètres mis à jour dans parent_gui.settings.")
         print(f"DEBUG (LocalSolverSettingsWindow _on_ok): Validation OK. Sauvegarde des settings. Préparation fermeture fenêtre.")
         print(f"  -> local_solver_preference: {solver_choice}")
         print(f"  -> local_ansvr_path à sauvegarder: {local_ansvr_path}")
+        print(f"  -> ansvr_host_port à sauvegarder: {ansvr_host_port}")
+        print(f"  -> astrometry_dir à sauvegarder: {astrometry_dir}")
+        print(f"  -> reproject_batches: {reproject_batches}")
         self.grab_release()
         self.destroy()
 

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -431,6 +431,9 @@ class SeestarStackerGUI:
         # --- NOUVELLE VARIABLE TKINTER POUR L'OPTION DE SAUVEGARDE ---
         self.save_as_float32_var = tk.BooleanVar(value=False) # Défaut à False (donc uint16)
         print(f"DEBUG (GUI init_variables): Variable save_as_float32_var créée (valeur initiale: {self.save_as_float32_var.get()}).")
+        self.reproject_batches_var = tk.BooleanVar(value=False)
+        self.ansvr_host_port_var = tk.StringVar(value='127.0.0.1:8080')
+        self.astrometry_solve_field_dir_var = tk.StringVar(value="")
         # --- FIN NOUVELLE VARIABLE ---
 
         print("DEBUG (GUI init_variables V_SaveAsFloat32_1): Fin initialisation variables Tkinter.") # Version Log
@@ -3203,6 +3206,8 @@ class SeestarStackerGUI:
                 env["ZEMOSAIC_LOCAL_ANSVR_PATH"] = str(self.settings.local_ansvr_path)
             if getattr(self.settings, "astrometry_api_key", ""):
                 env["ZEMOSAIC_ASTROMETRY_API_KEY"] = str(self.settings.astrometry_api_key)
+            if getattr(self.settings, "astrometry_solve_field_dir", ""):
+                env["ZEMOSAIC_ASTROMETRY_DIR"] = str(self.settings.astrometry_solve_field_dir)
             if getattr(self.settings, "local_solver_preference", ""):
                 env["ZEMOSAIC_LOCAL_SOLVER_PREFERENCE"] = str(self.settings.local_solver_preference)
             try:


### PR DESCRIPTION
## Summary
- bring back solver selection options in `local_solver_gui`
- add host/port and reprojection settings management
- expose new variables via `SettingsManager` and GUI
- allow setting ASTAP catalog directory and Astrometry solve-field location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6845dcfb5240832f99c19c9cb03db048