### PR TITLE
Enable optional batch reprojection

### DIFF
--- a/seestar/core/reprojection.py
+++ b/seestar/core/reprojection.py
@@ -1,0 +1,58 @@
+"""Utility functions for WCS reprojection."""
+
+from reproject import reproject_interp
+import numpy as np
+from astropy.wcs import WCS
+
+
+def reproject_to_reference_wcs(image_data, input_wcs, target_wcs, target_shape_hw):
+    """Reproject ``image_data`` from ``input_wcs`` to ``target_wcs``.
+
+    Parameters
+    ----------
+    image_data : np.ndarray
+        Image array ``HxW`` or ``HxWxC`` (float32 recommended).
+    input_wcs : astropy.wcs.WCS
+        World Coordinate System describing ``image_data``.
+    target_wcs : astropy.wcs.WCS
+        Target WCS to reproject onto.
+    target_shape_hw : tuple
+        Shape ``(H, W)`` of the desired output.
+
+    Returns
+    -------
+    np.ndarray
+        Reprojected array with the same dtype as ``image_data`` and
+        shape ``target_shape_hw`` (or ``target_shape_hw + (C,)`` if colour).
+
+    Raises
+    ------
+    RuntimeError
+        If the reprojection fails for any reason.
+    """
+
+    try:
+        if not isinstance(input_wcs, WCS) or not isinstance(target_wcs, WCS):
+            raise ValueError("input_wcs and target_wcs must be WCS instances")
+
+        if image_data.ndim == 2:
+            result, _ = reproject_interp((image_data, input_wcs),
+                                          target_wcs,
+                                          shape_out=tuple(target_shape_hw))
+            return result.astype(image_data.dtype)
+
+        if image_data.ndim == 3 and image_data.shape[2] in (3, 4):
+            channels = []
+            for ch in range(image_data.shape[2]):
+                res, _ = reproject_interp(
+                    (image_data[:, :, ch], input_wcs),
+                    target_wcs,
+                    shape_out=tuple(target_shape_hw),
+                )
+                channels.append(res.astype(image_data.dtype))
+            return np.stack(channels, axis=2)
+
+        raise ValueError("Unsupported image_data shape for reprojection")
+
+    except Exception as exc:
+        raise RuntimeError(f"Reprojection failed: {exc}")

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4234,7 +4234,8 @@ class SeestarStackerGUI:
             local_ansvr_path=self.settings.local_ansvr_path,
             local_solver_preference=self.settings.local_solver_preference,
             astap_search_radius=self.settings.astap_search_radius,
-            save_as_float32=self.settings.save_final_as_float32
+            save_as_float32=self.settings.save_final_as_float32,
+            enable_reprojection_between_batches=self.settings.enable_reprojection_between_batches
             # Lire depuis self.settings
             
         )


### PR DESCRIPTION
## Summary
- add `reproject_to_reference_wcs` util
- expose `enable_reprojection_between_batches` setting in backend and GUI
- reproject stacked batches before accumulation when option enabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ccdproc')*

------
https://chatgpt.com/codex/tasks/task_e_6845eaa67c44832fab6f4239e9256ce6