### PR TITLE
Rename interbatch reprojection setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ zemosaic_worker.run_hierarchical_mosaic(
 - `astrometry_solve_field_dir`: directory containing the `solve-field` executable
 - `api_key`: astrometry.net API key
 - `local_solver_preference`: preferred local solver (`astap` or `ansvr`)
-- `enable_reprojection_between_batches`: when true, reproject each batch using the previous batch's WCS
+- `enable_interbatch_reproj`: when true, reproject each batch using the previous batch's WCS
 
 `use_radec_hints` controls whether ASTAP receives the RA/DEC coordinates from
 the FITS header. This option is **disabled by default** and should only be

--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -96,7 +96,7 @@ class LocalSolverSettingsWindow(tk.Toplevel):
 
         self.reproject_batches_var = tk.BooleanVar(
             value=getattr(
-                self.parent_gui.settings, 'enable_reprojection_between_batches', False
+                self.parent_gui.settings, 'enable_interbatch_reproj', False
             )
         )
 
@@ -657,7 +657,7 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         setattr(self.parent_gui.settings, 'astap_search_radius', astap_radius)
         self.parent_gui.settings.local_ansvr_path = local_ansvr_path
         self.parent_gui.settings.ansvr_host_port = ansvr_host_port
-        self.parent_gui.settings.enable_reprojection_between_batches = reproject_batches
+        self.parent_gui.settings.enable_interbatch_reproj = reproject_batches
 
         self.parent_gui.settings.astrometry_solve_field_dir = astrometry_dir
 

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4264,7 +4264,7 @@ class SeestarStackerGUI:
             local_solver_preference=self.settings.local_solver_preference,
             astap_search_radius=self.settings.astap_search_radius,
             save_as_float32=self.settings.save_final_as_float32,
-            enable_reprojection_between_batches=self.settings.enable_reprojection_between_batches
+            enable_interbatch_reproj=self.settings.enable_interbatch_reproj
             # Lire depuis self.settings
             
         )

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -169,10 +169,10 @@ class SettingsManager:
 
             self.astrometry_solve_field_dir = getattr(self, 'astrometry_solve_field_dir', default_values_from_code.get('astrometry_solve_field_dir', ''))
 
-            self.enable_reprojection_between_batches = getattr(
+            self.enable_interbatch_reproj = getattr(
                 gui_instance,
                 'reproject_batches_var',
-                tk.BooleanVar(value=default_values_from_code.get('enable_reprojection_between_batches', False)),
+                tk.BooleanVar(value=default_values_from_code.get('enable_interbatch_reproj', False)),
             ).get()
             self.use_radec_hints = getattr(
                 gui_instance,
@@ -253,7 +253,7 @@ class SettingsManager:
 
             if not hasattr(self, 'astrometry_solve_field_dir'): self.astrometry_solve_field_dir = self.get_default_values()['astrometry_solve_field_dir']
 
-            if not hasattr(self, 'enable_reprojection_between_batches'): self.enable_reprojection_between_batches = self.get_default_values()['enable_reprojection_between_batches']
+            if not hasattr(self, 'enable_interbatch_reproj'): self.enable_interbatch_reproj = self.get_default_values()['enable_interbatch_reproj']
             
             getattr(gui_instance, 'use_weighting_var', tk.BooleanVar()).set(self.use_quality_weighting)
             getattr(gui_instance, 'weight_snr_var', tk.BooleanVar()).set(self.weight_by_snr)
@@ -371,7 +371,7 @@ class SettingsManager:
 
             getattr(gui_instance, 'astrometry_solve_field_dir_var', tk.StringVar()).set(self.astrometry_solve_field_dir)
 
-            getattr(gui_instance, 'reproject_batches_var', tk.BooleanVar()).set(self.enable_reprojection_between_batches)
+            getattr(gui_instance, 'reproject_batches_var', tk.BooleanVar()).set(self.enable_interbatch_reproj)
             
             print("DEBUG (Settings apply_to_ui V_SaveAsFloat32_1): Fin application paramètres UI.") # Version Log
             print("DEBUG (SettingsManager apply_to_ui V_LocalSolverPref): Fin application paramètres UI principale.") # Version Log (ancienne)
@@ -481,7 +481,7 @@ class SettingsManager:
 
         defaults_dict['astrometry_solve_field_dir'] = ""
 
-        defaults_dict['enable_reprojection_between_batches'] = False
+        defaults_dict['enable_interbatch_reproj'] = False
         
         defaults_dict['mosaic_mode_active'] = False
         defaults_dict['mosaic_settings'] = {
@@ -920,11 +920,11 @@ class SettingsManager:
             else:
                 self.astrometry_solve_field_dir = current_astrometry_dir.strip()
 
-            self.enable_reprojection_between_batches = bool(
+            self.enable_interbatch_reproj = bool(
                 getattr(
                     self,
-                    'enable_reprojection_between_batches',
-                    defaults_fallback['enable_reprojection_between_batches'],
+                    'enable_interbatch_reproj',
+                    defaults_fallback['enable_interbatch_reproj'],
                 )
             )
             print(f"DEBUG (SettingsManager validate_settings V_LocalSolverPref): Solveurs locaux validés: Pref='{self.local_solver_preference}', ASTAP Radius={self.astap_search_radius}")
@@ -1060,7 +1060,7 @@ class SettingsManager:
 
             'astrometry_solve_field_dir': str(getattr(self, 'astrometry_solve_field_dir', "")),
 
-            'enable_reprojection_between_batches': bool(getattr(self, 'enable_reprojection_between_batches', False)),
+            'enable_interbatch_reproj': bool(getattr(self, 'enable_interbatch_reproj', False)),
         }
 
         if 'use_local_solver_priority' in settings_data: # Nettoyage de l'ancienne clé si elle existait par erreur

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -242,7 +242,7 @@ class SeestarQueuedStacker:
         self.save_final_as_float32 = False # Par défaut, sauvegarde en uint16 (via conversion dans _save_final_stack)
         print(f"  -> Attribut self.save_final_as_float32 initialisé à: {self.save_final_as_float32}")
         # Option de reprojection des lots intermédiaires
-        self.enable_reprojection_between_batches = False
+        self.enable_interbatch_reproj = False
         # --- FIN NOUVEAU ---
 
         self.progress_callback = None; self.preview_callback = None
@@ -3409,7 +3409,7 @@ class SeestarQueuedStacker:
                 target_shape_hw = self.drizzle_output_shape_hw or self.memmap_shape[:2]
                 wcs_for_pixmap = wcs_input_from_file
                 input_shape_hw_current_file = image_hwc.shape[:2]
-                if self.enable_reprojection_between_batches and self.reference_wcs_object:
+                if self.enable_interbatch_reproj and self.reference_wcs_object:
                     try:
                         image_hwc = reproject_to_reference_wcs(
                             image_hwc,
@@ -3714,13 +3714,13 @@ class SeestarQueuedStacker:
 
         
         input_wcs = batch_wcs
-        if input_wcs is None and self.enable_reprojection_between_batches and self.reference_wcs_object:
+        if input_wcs is None and self.enable_interbatch_reproj and self.reference_wcs_object:
             try:
                 input_wcs = WCS(stack_info_header, naxis=2)
             except Exception:
                 input_wcs = None
 
-        if self.enable_reprojection_between_batches and self.reference_wcs_object and input_wcs is not None:
+        if self.enable_interbatch_reproj and self.reference_wcs_object and input_wcs is not None:
             try:
                 stacked_batch_data_np = reproject_to_reference_wcs(
                     stacked_batch_data_np, input_wcs, self.reference_wcs_object, expected_shape_hw
@@ -3802,7 +3802,7 @@ class SeestarQueuedStacker:
             batch_sum = signal_to_add_to_sum_float64.astype(np.float32)
             batch_wht = batch_coverage_map_2d.astype(np.float32)
             try:
-                if self.enable_reprojection_between_batches and self.reference_wcs_object and batch_wcs is not None:
+                if self.enable_interbatch_reproj and self.reference_wcs_object and batch_wcs is not None:
                     from reproject import reproject_interp
                     shp = self.memmap_shape[:2]
                     if batch_sum.ndim == 3:
@@ -4990,14 +4990,14 @@ class SeestarQueuedStacker:
                          astap_search_radius=3.0,
                          local_solver_preference="none",
                          save_as_float32=False, # <-- NOUVEL ARGUMENT AJOUTÉ ICI
-                         enable_reprojection_between_batches=False
+                         enable_interbatch_reproj=False
                          ):
         print(f"!!!!!!!!!! VALEUR BRUTE ARGUMENT astap_search_radius REÇU : {astap_search_radius} !!!!!!!!!!")
         print(f"!!!!!!!!!! VALEUR BRUTE ARGUMENT save_as_float32 REÇU : {save_as_float32} !!!!!!!!!!") # DEBUG
                          
         """
         Démarre le thread de traitement principal avec la configuration spécifiée.
-        MODIFIED: Ajout arguments save_as_float32 et enable_reprojection_between_batches.
+        MODIFIED: Ajout arguments save_as_float32 et enable_interbatch_reproj.
         Version: V_StartProcessing_SaveDtypeOption_1
         """
         print("DEBUG QM (start_processing V_StartProcessing_SaveDtypeOption_1): Début tentative démarrage...") # Version Log
@@ -5009,7 +5009,7 @@ class SeestarQueuedStacker:
         print(f"    drizzle_mode (global arg de func): {drizzle_mode}")
         print(f"    mosaic_settings (dict brut): {mosaic_settings}")
         print(f"    save_as_float32 (arg de func): {save_as_float32}") # Log du nouvel argument
-        print(f"    enable_reprojection_between_batches (arg de func): {enable_reprojection_between_batches}")
+        print(f"    enable_interbatch_reproj (arg de func): {enable_interbatch_reproj}")
         print(f"    output_filename (arg de func): {output_filename}")
         print("  --- FIN BACKEND ARGS REÇUS ---")
 
@@ -5110,7 +5110,7 @@ class SeestarQueuedStacker:
         # --- NOUVEAU : Assignation du paramètre de sauvegarde à l'attribut de l'instance ---
         self.save_final_as_float32 = bool(save_as_float32)
         print(f"    [OutputFormat] self.save_final_as_float32 (attribut d'instance) mis à : {self.save_final_as_float32} (depuis argument {save_as_float32})")
-        self.enable_reprojection_between_batches = bool(enable_reprojection_between_batches)
+        self.enable_interbatch_reproj = bool(enable_interbatch_reproj)
         # --- FIN NOUVEAU ---
 
         self.mosaic_settings_dict = mosaic_settings if isinstance(mosaic_settings, dict) else {}


### PR DESCRIPTION
## Summary
- rename all references of `enable_reprojection_between_batches` to `enable_interbatch_reproj`
- support the new setting in the GUI
- adjust queue manager argument and attribute
- update README documentation

## Testing
- `pytest -q` *(fails: No module named 'ccdproc')*

------
https://chatgpt.com/codex/tasks/task_e_68461c288dcc832f9c35ca351f006b20