### PR TITLE
Enable reference WCS solving for inter-batch reprojection

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,7 @@ zemosaic_worker.run_hierarchical_mosaic(
 - `api_key`: astrometry.net API key
 - `local_solver_preference`: preferred local solver (`astap` or `ansvr`)
 
-- `reproject_between_batches`: when true, reproject each batch using the project's reference WCS
-
+- `reproject_between_batches`: when true, reproject each batch using the project's reference WCS. When enabled in classic stacking, the reference image is plate-solved automatically.
 
 `use_radec_hints` controls whether ASTAP receives the RA/DEC coordinates from
 the FITS header. This option is **disabled by default** and should only be

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -5434,7 +5434,7 @@ class SeestarQueuedStacker:
 
             self.reference_wcs_object = None 
             
-            if self.drizzle_active_session or self.is_mosaic_run: 
+            if self.drizzle_active_session or self.is_mosaic_run or self.reproject_between_batches:
                 print("DEBUG QM (start_processing): Plate-solving de la référence principale requis...")
                 
                 if not os.path.exists(reference_image_path_for_solving):
@@ -5504,9 +5504,11 @@ class SeestarQueuedStacker:
                     else: 
                         self.update_progress("❌ ERREUR CRITIQUE: Impossible d'obtenir un WCS pour la référence globale. Drizzle/Mosaïque ne peut continuer.", "ERROR")
                         return False 
-            else: 
-                print("DEBUG QM (start_processing): Plate-solving de la référence globale ignoré (mode Stacking Classique seul).")
-                self.reference_wcs_object = None 
+            else:
+                print(
+                    "DEBUG QM (start_processing): Plate-solving de la référence globale ignoré (mode Stacking Classique sans reprojection)."
+                )
+                self.reference_wcs_object = None
             
             if reference_image_data_for_shape_determination is not None:
                 del reference_image_data_for_shape_determination


### PR DESCRIPTION
## Summary
- solve the reference WCS when `reproject_between_batches` is enabled
- clarify log message when solving is skipped
- document that classic stacking with reprojection will plate-solve the reference

## Testing
- `python -m pytest -q` *(fails: tests/test_mosaic_worker.py::test_resolve_after_crop, tests/test_mosaic_worker.py::test_solver_header_values_no_wcs, tests/test_mosaic_worker.py::test_use_sidecar_wcs, tests/test_mosaic_worker.py::test_output_scale_warning_and_adjust, tests/test_mosaic_worker.py::test_grid_uses_resolved_wcs)*

------
https://chatgpt.com/codex/tasks/task_e_6846b4f0b168832f90d89fb131c5382d