### PR TITLE
Fix ASTAP stack solve by using grayscale

### DIFF
--- a/seestar/alignment/astrometry_solver.py
+++ b/seestar/alignment/astrometry_solver.py
@@ -502,7 +502,7 @@ class AstrometrySolver:
 
 
 
-# --- DANS LA CLASSE AstrometrySolver DANS seestar/alignment/astrometry_solver.py ---
+    # --- DANS LA CLASSE AstrometrySolver DANS seestar/alignment/astrometry_solver.py ---
 
     def _try_solve_local_ansvr(self, image_path, fits_header,
                                ansvr_user_provided_path,
@@ -701,14 +701,9 @@ class AstrometrySolver:
         self._log("Pixel scale derivation failed due to missing keywords", "DEBUG")
         return None
 
+
     # ... (méthodes _try_solve_astap, _solve_astrometry_net_web, _parse_wcs_file_content, _update_fits_header_with_wcs existantes) ...
     # Note: la méthode _try_solve_astap est celle que tu as déjà modifiée pour le nettoyage.
-
-# --- END OF FILE seestar/alignment/astrometry_solver.py ---
-
-
-
-# --- DANS LA CLASSE AstrometrySolver DANS seestar/alignment/astrometry_solver.py ---
 
     def _try_solve_astap(
         self,
@@ -1099,7 +1094,7 @@ class AstrometrySolver:
             traceback.print_exc(limit=1)
             return None
 
-def _update_fits_header_with_wcs(self, fits_header, wcs_object, solver_name="UnknownSolver"):
+    def _update_fits_header_with_wcs(self, fits_header, wcs_object, solver_name="UnknownSolver"):
         """
         Met à jour un header FITS existant avec les informations d'un objet WCS.
         """

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3308,12 +3308,12 @@ class SeestarQueuedStacker:
             try:
                 temp_f = tempfile.NamedTemporaryFile(suffix=".fits", delete=False)
                 temp_f.close()
-                data_to_write = stacked_batch_data_np
-                if stacked_batch_data_np.ndim == 3 and stacked_batch_data_np.shape[2] == 3:
-                    data_to_write = np.moveaxis(stacked_batch_data_np, -1, 0)
+                img_for_solver = stacked_batch_data_np
+                if img_for_solver.ndim == 3:
+                    img_for_solver = img_for_solver[..., 0]
                 fits.writeto(
                     temp_f.name,
-                    data_to_write.astype(np.float32),
+                    img_for_solver.astype(np.float32),
                     header=stack_info_header,
                     overwrite=True,
                 )


### PR DESCRIPTION
## Summary
- convert intermediate batch stacks to grayscale before running ASTAP

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846c32f49f0832fab91e6b2578336b0