### PR TITLE
Log image counter and add unit test

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4144,9 +4144,18 @@ class SeestarQueuedStacker:
 
 
             # Mise à jour des compteurs globaux
-            self.images_in_cumulative_stack += num_physical_images_in_batch # Compte les images physiques
+            self.images_in_cumulative_stack += num_physical_images_in_batch  # Compte les images physiques
             self.total_exposure_seconds += batch_exposure
-            print(f"DEBUG QM [_combine_batch_result SUM/W]: Compteurs mis à jour: images_in_cumulative_stack={self.images_in_cumulative_stack}, total_exposure_seconds={self.total_exposure_seconds:.1f}")
+            print(
+                f"DEBUG QM [_combine_batch_result SUM/W]: images ajoutées="
+                f"{num_physical_images_in_batch}, nouveau total="
+                f"{self.images_in_cumulative_stack}"
+            )
+            print(
+                f"DEBUG QM [_combine_batch_result SUM/W]: Compteurs mis à jour: "
+                f"images_in_cumulative_stack={self.images_in_cumulative_stack}, "
+                f"total_exposure_seconds={self.total_exposure_seconds:.1f}"
+            )
 
             # --- Mise à jour Header Cumulatif (comme avant) ---
             if self.current_stack_header is None:

--- a/tests/test_interbatch_classic.py
+++ b/tests/test_interbatch_classic.py
@@ -30,6 +30,7 @@ class DummyStacker:
         self.cumulative_sum_memmap = np.zeros(self.memmap_shape, dtype=np.float32)
         self.cumulative_wht_memmap = np.zeros(self.memmap_shape[:2], dtype=np.float32)
         self.enable_inter_batch_reprojection = True
+        self.images_in_cumulative_stack = 0
 
     def _reproject_batch_to_reference(self, img, wht, wcs_in):
         reproject_interp = reproject_utils.reproject_interp
@@ -49,6 +50,7 @@ class DummyStacker:
         signal = data.astype(np.float64) * coverage.astype(np.float64)[:, :, np.newaxis]
         self.cumulative_sum_memmap += signal.astype(np.float32)
         self.cumulative_wht_memmap += coverage.astype(np.float32)
+        self.images_in_cumulative_stack += 1
 
 
 def test_inter_batch_reprojection_range(tmp_path):
@@ -72,3 +74,14 @@ def test_inter_batch_reprojection_range(tmp_path):
     result = s.cumulative_sum_memmap / s.cumulative_wht_memmap[:, :, np.newaxis]
     assert result.min() >= 0
     assert result.max() <= 1
+
+
+def test_cumulative_stack_counter():
+    s = DummyStacker()
+
+    for _ in range(4):
+        img = np.ones(s.memmap_shape, dtype=np.float32)
+        cov = np.ones(s.memmap_shape[:2], dtype=np.float32)
+        s._combine_batch_result(img, fits.Header(), cov)
+
+    assert s.images_in_cumulative_stack == 4


### PR DESCRIPTION
## Summary
- log number of images added to cumulative stack after each batch
- extend `DummyStacker` used in tests with counter
- add unit test validating the counter increments

## Testing
- `pytest -q` *(fails: test_mosaic_worker)*

------
https://chatgpt.com/codex/tasks/task_e_684767859ff4832f8005167fb8284f66