### PR TITLE
Improve zero coverage logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ La pondération par qualité vise à améliorer le stack final en donnant plus d
 *   **Warning: Low Variance:** Normal for very dark/cloudy frames.
 *   **App Starts with Invalid Paths:** Use "Browse" to select valid paths before starting. The app checks paths on "Start".
 *   **Quality Weighting Issues:** Try lowering exponents (< 1.0) or disabling one metric (SNR/Stars). Ensure Min Weight is low (0.05-0.15).
+*   **Zero Coverage Warning:** If logs show `Cumulative weight map sums to zero`, no pixels were accumulated. Verify all batch images share the expected shape and that reprojection is configured correctly.
 
 **(Français)**
 
@@ -380,6 +381,7 @@ La pondération par qualité vise à améliorer le stack final en donnant plus d
 *   **Avertissement : Faible Variance :** Normal pour images très sombres/nuageuses.
 *   **L'App Démarre avec des Chemins Invalides :** Utilisez "Parcourir" pour sélectionner des chemins valides avant de démarrer. L'app vérifie les chemins au "Démarrage".
 *   **Problèmes Pondération Qualité :** Essayez de baisser les exposants (< 1.0) ou désactivez une métrique (SNR/Étoiles). Assurez-vous que Poids Min est bas (0.05-0.15).
+*   **Avertissement Couverture Zéro :** Si les logs affichent `Carte de poids cumulée entièrement nulle`, aucune image n'a été ajoutée au stack. Vérifiez la cohérence des dimensions et la configuration de la reprojection.
 
 ---
 

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4212,7 +4212,14 @@ class SeestarQueuedStacker:
                     f"WHT {pre_wht_min:.3f}->{post_wht_min:.3f}, {pre_wht_max:.3f}->{post_wht_max:.3f}"
                 )
                 if np.isclose(pre_sum_min, post_sum_min) and np.isclose(pre_sum_max, post_sum_max):
-                    print("WARNING QM [_combine_batch_result]: cumulative SUM memmap unchanged after +=, possible dtype/broadcasting issue")
+                    warn_msg = (
+                        f"⚠️ Batch #{current_batch_num} addition produced no change to cumulative SUM. "
+                        "Possible dtype/broadcast issue."
+                    )
+                    print(
+                        "WARNING QM [_combine_batch_result]: cumulative SUM memmap unchanged after +=, possible dtype/broadcasting issue"
+                    )
+                    self.update_progress(warn_msg, "WARN")
             except Exception as dbg_e:
                 print(f"DEBUG QM [_combine_batch_result SUM/W]: erreur stats apres += : {dbg_e}")
             print("DEBUG QM [_combine_batch_result SUM/W]: Addition SUM/WHT terminée.")


### PR DESCRIPTION
## Summary
- log via `update_progress` if batch addition leaves the cumulative sum unchanged
- document zero coverage warnings in the README

## Testing
- `SEESTAR_VERBOSE=1 pytest -q` *(fails: ImportError in zemosaic modules)*

------
https://chatgpt.com/codex/tasks/task_e_6847cb30f7dc832f8aa110a7f58c9164