### PR TITLE
Add debug print for stack counts and new test

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4266,6 +4266,10 @@ class SeestarQueuedStacker:
 
             self.images_in_cumulative_stack += num_physical_images_in_batch # Compte les images physiques
             self.total_exposure_seconds += batch_exposure
+            print(
+                f"DEBUG QM [_combine_batch_result SUM/W]: {num_physical_images_in_batch} images ajoutées -> "
+                f"images_in_cumulative_stack={self.images_in_cumulative_stack}"
+            )
             print(f"DEBUG QM [_combine_batch_result SUM/W]: Compteurs mis à jour: images_in_cumulative_stack={self.images_in_cumulative_stack}, total_exposure_seconds={self.total_exposure_seconds:.1f}")
             self.update_progress(
                 f"📊 images_in_cumulative_stack={self.images_in_cumulative_stack}",


### PR DESCRIPTION
## Summary
- print stack counter increments inside `_combine_batch_result`
- extend tests for classic inter-batch stacking to check header NIMAGES

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d27d6420832f944863ad16cec551