### PR TITLE
Fix classic stacking output calculation

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -5143,15 +5143,19 @@ class SeestarQueuedStacker:
                 
                 self._close_memmaps() 
                 
+                eps = 1e-9
                 final_wht_map_for_postproc = np.maximum(final_wht_map_2d_from_memmap, 0.0)
-                wht_for_div_classic = np.maximum(final_wht_map_2d_from_memmap.astype(np.float64), 1e-9)
-                wht_for_div_classic_broadcastable = wht_for_div_classic[:, :, np.newaxis]
-                
-                with np.errstate(divide='ignore', invalid='ignore'): 
-                    final_image_initial_raw = final_sum / wht_for_div_classic_broadcastable
-                final_image_initial_raw = np.nan_to_num(final_image_initial_raw, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32)
-                self.update_progress(f"    DEBUG QM: Classic Mode - final_image_initial_raw (HWC, après SUM/WHT et nan_to_num) - Range: [{np.nanmin(final_image_initial_raw):.4g} - {np.nanmax(final_image_initial_raw):.4g}]")
-                print(f"    DEBUG QM: Classic Mode - final_image_initial_raw (HWC, après SUM/WHT et nan_to_num) - Range: [{np.nanmin(final_image_initial_raw):.4g} - {np.nanmax(final_image_initial_raw):.4g}]")
+                wht_safe = np.maximum(final_wht_map_2d_from_memmap, eps)[..., np.newaxis]
+
+                with np.errstate(divide='ignore', invalid='ignore'):
+                    final_image_initial_raw = final_sum / wht_safe
+                final_image_initial_raw = np.nan_to_num(final_image_initial_raw,
+                                                      nan=0.0, posinf=0.0, neginf=0.0)
+                final_image_initial_raw = final_image_initial_raw.astype(np.float32)
+                self.update_progress(
+                    f"    DEBUG QM: Classic Mode - final_image_initial_raw (HWC, après SUM/WHT et nan_to_num) - Range: [{np.nanmin(final_image_initial_raw):.4g} - {np.nanmax(final_image_initial_raw):.4g}]")
+                print(
+                    f"    DEBUG QM: Classic Mode - final_image_initial_raw (HWC, après SUM/WHT et nan_to_num) - Range: [{np.nanmin(final_image_initial_raw):.4g} - {np.nanmax(final_image_initial_raw):.4g}]")
 
         except Exception as e_get_raw:
             self.processing_error = f"Erreur obtention donnees brutes finales: {e_get_raw}"


### PR DESCRIPTION
## Summary
- fix how final sum/wht arrays are combined in classic mode

## Testing
- `pytest -q` *(fails: tests/test_mosaic_worker.py::test_resolve_after_crop, tests/test_mosaic_worker.py::test_solver_header_values_no_wcs, tests/test_mosaic_worker.py::test_use_sidecar_wcs, tests/test_mosaic_worker.py::test_output_scale_warning_and_adjust, tests/test_mosaic_worker.py::test_grid_uses_resolved_wcs)*

------
https://chatgpt.com/codex/tasks/task_e_6847d6b3a920832fb3fcb0dbc31a0d71