### PR TITLE
Fix inter-batch reprojection checkbox state

### DIFF
--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -100,9 +100,6 @@ class LocalSolverSettingsWindow(tk.Toplevel):
             )
         )
 
-        if not self.reproject_batches_var.get() and self._solver_configured():
-            self.reproject_batches_var.set(True)
-
         self.reproject_batches_var.trace_add('write', lambda *args: self._update_warning())
         self.local_solver_choice_var.trace_add('write', lambda *args: self._update_warning())
 

--- a/zemosaic/__init__.py
+++ b/zemosaic/__init__.py
@@ -1,0 +1,17 @@
+
+"""Initialize zemosaic package and expose modules with legacy names."""
+
+from importlib import import_module
+import sys
+
+for _name in [
+    "zemosaic_utils",
+    "zemosaic_astrometry",
+    "zemosaic_align_stack",
+    "zemosaic_config",
+]:
+    try:
+        mod = import_module(f".{_name}", __name__)
+        sys.modules[_name] = mod
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- keep the 'Enable inter-batch reprojection' checkbox from forcing itself on
- expose zemosaic modules under legacy names for tests

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: test_mosaic_worker.py)*

------
https://chatgpt.com/codex/tasks/task_e_6847e32a39b4832f979d65eb85dd0ee2