### PR TITLE
Consolidate inter-batch reprojection option

### DIFF
--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -175,12 +175,6 @@ class SettingsManager:
                 tk.BooleanVar(value=default_values_from_code.get('reproject_between_batches', False)),
             ).get()
 
-            self.inter_batch_reprojection = getattr(
-                gui_instance,
-                'inter_batch_reproj_var',
-                tk.BooleanVar(value=default_values_from_code.get('inter_batch_reprojection', False)),
-            ).get()
-
             self.use_radec_hints = getattr(
                 gui_instance,
                 'use_radec_hints_var',
@@ -381,8 +375,6 @@ class SettingsManager:
 
             getattr(gui_instance, 'reproject_batches_var', tk.BooleanVar()).set(self.reproject_between_batches)
 
-            getattr(gui_instance, 'inter_batch_reproj_var', tk.BooleanVar()).set(self.inter_batch_reprojection)
-
             
             print("DEBUG (Settings apply_to_ui V_SaveAsFloat32_1): Fin application paramètres UI.") # Version Log
             print("DEBUG (SettingsManager apply_to_ui V_LocalSolverPref): Fin application paramètres UI principale.") # Version Log (ancienne)
@@ -494,7 +486,6 @@ class SettingsManager:
 
 
         defaults_dict['reproject_between_batches'] = False
-        defaults_dict['inter_batch_reprojection'] = False
 
         
         defaults_dict['mosaic_mode_active'] = False
@@ -943,14 +934,6 @@ class SettingsManager:
                 )
             )
 
-            self.inter_batch_reprojection = bool(
-                getattr(
-                    self,
-                    'inter_batch_reprojection',
-                    defaults_fallback['inter_batch_reprojection'],
-                )
-            )
-
             print(f"DEBUG (SettingsManager validate_settings V_LocalSolverPref): Solveurs locaux validés: Pref='{self.local_solver_preference}', ASTAP Radius={self.astap_search_radius}")
 
             # Validation du facteur d'échelle mosaïque
@@ -1086,7 +1069,6 @@ class SettingsManager:
             'astrometry_solve_field_dir': str(getattr(self, 'astrometry_solve_field_dir', "")),
 
             'reproject_between_batches': bool(getattr(self, 'reproject_between_batches', False)),
-            'inter_batch_reprojection': bool(getattr(self, 'inter_batch_reprojection', False)),
 
         }
 

--- a/tests/test_interbatch_classic.py
+++ b/tests/test_interbatch_classic.py
@@ -29,7 +29,7 @@ class DummyStacker:
         self.reference_wcs_object = make_wcs(shape=self.memmap_shape[:2])
         self.cumulative_sum_memmap = np.zeros(self.memmap_shape, dtype=np.float32)
         self.cumulative_wht_memmap = np.zeros(self.memmap_shape[:2], dtype=np.float32)
-        self.enable_inter_batch_reprojection = True
+        self.reproject_between_batches = True
         self.images_in_cumulative_stack = 0
 
     def _reproject_batch_to_reference(self, img, wht, wcs_in):


### PR DESCRIPTION
## Summary
- merge various inter-batch reprojection flags into a single
  `reproject_between_batches` attribute
- update settings manager and GUI helpers to use the unified option
- adjust unit tests for the new attribute

## Testing
- `pytest -q` *(fails: test_mosaic_worker.py: five tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847f2a3d964832fb58600652d2ed5ce