### PR TITLE
Modify plate solving message logic

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1621,9 +1621,16 @@ class SeestarQueuedStacker:
 
 
             # --- 1.A Plate-solving de la référence ---
-            self.update_progress("DEBUG WORKER: Section 1.A - Plate-solving de la référence...")
-            self.reference_wcs_object = None 
-            temp_wcs_ancre = None # Spécifique pour la logique mosaïque locale
+            if self.drizzle_active_session or self.is_mosaic_run or self.reproject_between_batches:
+                self.update_progress(
+                    "DEBUG WORKER: Section 1.A - Plate-solving de la référence..."
+                )
+            else:
+                logger.debug(
+                    "DEBUG QM [_worker]: Plate-solving de la référence ignoré (mode Stacking Classique sans reprojection)."
+                )
+            self.reference_wcs_object = None
+            temp_wcs_ancre = None  # Spécifique pour la logique mosaïque locale
 
             logger.debug(f"!!!! DEBUG _WORKER AVANT CRÉATION DICT SOLVEUR ANCRE !!!!")
             logger.debug(f"    self.is_mosaic_run = {self.is_mosaic_run}")


### PR DESCRIPTION
## Summary
- log "Plate-solving" message in `_worker` only when solving will run
- emit debug log when solving is skipped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848009e62c4832fa486a5a6be56dbb1