### PR TITLE
Add preserve_linear_output setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Seestar Stacker est une application graphique conçue pour aligner et empiler de
     *   Multi-language Support (English, French).
     *   Customizable: Supports custom application icon and preview background image.
 *   **Configuration:** Saves and loads user settings (`seestar_settings.json`).
+*   **Output Format:** Save FITS stacks as float32 or uint16. Enable *Preserve Linear Output* to skip percentile scaling.
 *   **Workflow Tools:** Add folders during processing, Copy Log button, Open Output Folder button, optional temporary file cleanup.
 *   **Smart Quality Control:**
     *   SNR-based weighting
@@ -52,6 +53,7 @@ Seestar Stacker est une application graphique conçue pour aligner et empiler de
     *   Support Multilingue (Anglais, Français).
     *   Personnalisable : Supporte une icône d'application et une image de fond d'aperçu personnalisées.
 *   **Configuration :** Sauvegarde et charge les paramètres utilisateur (`seestar_settings.json`).
+*   **Format de Sortie :** Sauvegarde des FITS en float32 ou uint16. Activez *Préserver l'image linéaire* pour éviter la normalisation par percentiles.
 *   **Outils de Workflow :** Ajout de dossiers pendant le traitement, bouton Copier Log, bouton Ouvrir Dossier Sortie, nettoyage optionnel des fichiers temporaires.
 *   **Contrôle Qualité Intelligent :**
     *   Pondération par rapport signal/bruit (SNR)

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -450,12 +450,16 @@ class SeestarStackerGUI:
         
         self.apply_low_wht_mask_var = tk.BooleanVar(value=False) 
         self.low_wht_pct_var = tk.IntVar(value=5)                
-        self.low_wht_soften_px_var = tk.IntVar(value=128)        
+        self.low_wht_soften_px_var = tk.IntVar(value=128)
         print("DEBUG (GUI init_variables): Variables Low WHT Mask créées.")
 
         # --- NOUVELLE VARIABLE TKINTER POUR L'OPTION DE SAUVEGARDE ---
         self.save_as_float32_var = tk.BooleanVar(value=False) # Défaut à False (donc uint16)
         print(f"DEBUG (GUI init_variables): Variable save_as_float32_var créée (valeur initiale: {self.save_as_float32_var.get()}).")
+        self.preserve_linear_output_var = tk.BooleanVar(value=False)
+        print(
+            f"DEBUG (GUI init_variables): Variable preserve_linear_output_var créée (valeur initiale: {self.preserve_linear_output_var.get()})."
+        )
         self.reproject_between_batches_var = tk.BooleanVar(value=False)
         self.ansvr_host_port_var = tk.StringVar(value='127.0.0.1:8080')
 
@@ -1007,13 +1011,24 @@ class SeestarStackerGUI:
         print("DEBUG (GUI create_layout): Output Format Frame créé.")
 
         self.save_as_float32_check = ttk.Checkbutton(
-            self.output_format_frame, 
-            text=self.tr("save_as_float32_label", default="Save final FITS as float32 (larger files, max precision)"), 
+            self.output_format_frame,
+            text=self.tr("save_as_float32_label", default="Save final FITS as float32 (larger files, max precision)"),
             variable=self.save_as_float32_var # Variable Tkinter créée dans init_variables
         )
         self.save_as_float32_check.pack(anchor=tk.W, padx=5, pady=5)
         # Pas besoin de command ici, la valeur sera lue par SettingsManager.update_from_ui()
         print("DEBUG (GUI create_layout): Checkbutton save_as_float32 créé.")
+
+        self.preserve_linear_output_check = ttk.Checkbutton(
+            self.output_format_frame,
+            text=self.tr(
+                "preserve_linear_output_label",
+                default="Preserve linear output (skip percentile scaling)",
+            ),
+            variable=self.preserve_linear_output_var,
+        )
+        self.preserve_linear_output_check.pack(anchor=tk.W, padx=5, pady=2)
+        print("DEBUG (GUI create_layout): Checkbutton preserve_linear_output créé.")
         # --- FIN NOUVEAU ---
         
         self.reset_expert_button = ttk.Button(expert_content_frame, text=self.tr("reset_expert_button", default="Reset Expert Settings"), command=self._reset_expert_settings)
@@ -1734,7 +1749,7 @@ class SeestarStackerGUI:
     def _store_widget_references(self):
         """
         Stocke les références aux widgets qui nécessitent des mises à jour linguistiques et des infobulles.
-        MODIFIED: Ajout de la référence pour save_as_float32_check.
+        MODIFIED: Ajout des références pour save_as_float32_check et preserve_linear_output_check.
         """
         print("\nDEBUG (GUI _store_widget_references V_SaveAsFloat32_1): Début stockage références widgets...") # Version Log
         notebook_widget = None
@@ -1837,7 +1852,8 @@ class SeestarStackerGUI:
             "cleanup_temp_check_label": 'cleanup_temp_check',
             "chroma_correction_check": 'chroma_correction_check',
             # NOUVEAU : Clé pour le texte de la nouvelle Checkbutton
-            "save_as_float32_label": 'save_as_float32_check'
+            "save_as_float32_label": 'save_as_float32_check',
+            "preserve_linear_output_label": 'preserve_linear_output_check'
         }
         for key, item in labels_and_checks_keys.items():
             if isinstance(item, tk.Widget): self.widgets_to_translate[key] = item
@@ -1902,7 +1918,8 @@ class SeestarStackerGUI:
             ('low_wht_soften_px_label', 'tooltip_low_wht_soften_px'),
             ('low_wht_soften_px_spinbox', 'tooltip_low_wht_soften_px'),
             # NOUVEAU : Tooltip pour la nouvelle Checkbutton
-            ('save_as_float32_check', 'tooltip_save_as_float32')
+            ('save_as_float32_check', 'tooltip_save_as_float32'),
+            ('preserve_linear_output_check', 'tooltip_preserve_linear_output')
         ]
         
         tooltip_created_count = 0
@@ -4288,6 +4305,7 @@ class SeestarStackerGUI:
             "local_solver_preference": self.settings.local_solver_preference,
             "astap_search_radius": self.settings.astap_search_radius,
             "save_as_float32": self.settings.save_final_as_float32,
+            "preserve_linear_output": self.settings.preserve_linear_output,
             "reproject_between_batches": self.settings.reproject_between_batches,
         }
         import inspect

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -142,10 +142,21 @@ class SettingsManager:
                      self.window_geometry = current_geo_ui
             
             # --- NOUVEAU : Lecture du setting pour la sauvegarde en float32 ---
-            self.save_final_as_float32 = getattr(gui_instance, 'save_as_float32_var', 
+            self.save_final_as_float32 = getattr(gui_instance, 'save_as_float32_var',
                                                  tk.BooleanVar(value=default_values_from_code.get('save_final_as_float32', False))
                                                 ).get()
             logger.debug(f"DEBUG SM (update_from_ui): self.save_final_as_float32 lu (attribut UI ou défaut): {self.save_final_as_float32}")
+            # --- FIN NOUVEAU ---
+
+            # --- NOUVEAU : Lecture du setting preserve_linear_output ---
+            self.preserve_linear_output = getattr(
+                gui_instance,
+                'preserve_linear_output_var',
+                tk.BooleanVar(value=default_values_from_code.get('preserve_linear_output', False)),
+            ).get()
+            logger.debug(
+                f"DEBUG SM (update_from_ui): self.preserve_linear_output lu (attribut UI ou défaut): {self.preserve_linear_output}"
+            )
             # --- FIN NOUVEAU ---
 
             self.mosaic_mode_active = bool(getattr(gui_instance, 'mosaic_mode_active', default_values_from_code.get('mosaic_mode_active', False)))
@@ -347,6 +358,13 @@ class SettingsManager:
             getattr(gui_instance, 'save_as_float32_var', tk.BooleanVar()).set(self.save_final_as_float32)
             logger.debug(f"DEBUG (Settings apply_to_ui): save_final_as_float32 appliqué à l'UI (valeur: {self.save_final_as_float32})")
             # --- FIN NOUVEAU ---
+
+            # --- NOUVEAU : Application du setting preserve_linear_output ---
+            getattr(gui_instance, 'preserve_linear_output_var', tk.BooleanVar()).set(self.preserve_linear_output)
+            logger.debug(
+                f"DEBUG (Settings apply_to_ui): preserve_linear_output appliqué à l'UI (valeur: {self.preserve_linear_output})"
+            )
+            # --- FIN NOUVEAU ---
             
             getattr(gui_instance, 'preview_stretch_method', tk.StringVar()).set(self.preview_stretch_method)
             getattr(gui_instance, 'preview_black_point', tk.DoubleVar()).set(self.preview_black_point)
@@ -467,13 +485,20 @@ class SettingsManager:
         defaults_dict['photutils_bn_exclude_percentile'] = 95.0 
         defaults_dict['apply_feathering'] = True 
         defaults_dict['feather_blur_px'] = 256   
-        defaults_dict['apply_low_wht_mask'] = False   
-        defaults_dict['low_wht_percentile'] = 5       
-        defaults_dict['low_wht_soften_px'] = 128      
-        
+        defaults_dict['apply_low_wht_mask'] = False
+        defaults_dict['low_wht_percentile'] = 5
+        defaults_dict['low_wht_soften_px'] = 128
+
         # --- NOUVEAU : Paramètre de sauvegarde float32 ---
         defaults_dict['save_final_as_float32'] = False # Défaut à False (donc uint16 après mise à l'échelle par défaut)
         logger.debug(f"DEBUG (SettingsManager get_default_values): Ajout de 'save_final_as_float32'={defaults_dict['save_final_as_float32']}")
+        # --- FIN NOUVEAU ---
+
+        # --- NOUVEAU : Préserver la sortie linéaire ---
+        defaults_dict['preserve_linear_output'] = False
+        logger.debug(
+            f"DEBUG (SettingsManager get_default_values): Ajout de 'preserve_linear_output'={defaults_dict['preserve_linear_output']}"
+        )
         # --- FIN NOUVEAU ---
 
         # --- Paramètres Solveurs Locaux ---
@@ -849,6 +874,20 @@ class SettingsManager:
                 self.save_final_as_float32 = current_save_float32_val
             # --- FIN NOUVEAU ---
 
+            # --- NOUVEAU : Validation du setting preserve_linear_output ---
+            logger.debug("    -> Validating Preserve Linear Output...")
+            current_preserve_val = getattr(
+                self, 'preserve_linear_output', defaults_fallback['preserve_linear_output']
+            )
+            if not isinstance(current_preserve_val, bool):
+                messages.append(
+                    f"Option 'Preserve Linear Output' ('{current_preserve_val}') invalide, réinitialisée à {defaults_fallback['preserve_linear_output']}."
+                )
+                self.preserve_linear_output = defaults_fallback['preserve_linear_output']
+            else:
+                self.preserve_linear_output = current_preserve_val
+            # --- FIN NOUVEAU ---
+
             # --- Local Solver Paths and ASTAP Search Radius ---
             # ... (inchangé) ...
             logger.debug("  -> Validating Local Solver Settings...")
@@ -1055,11 +1094,15 @@ class SettingsManager:
             'apply_low_wht_mask': bool(self.apply_low_wht_mask),
             'low_wht_percentile': int(self.low_wht_percentile),
             'low_wht_soften_px': int(self.low_wht_soften_px),
-            
+
             # --- NOUVEAU : Sauvegarde du setting save_final_as_float32 ---
             'save_final_as_float32': bool(getattr(self, 'save_final_as_float32', False)),
             # --- FIN NOUVEAU ---
-            
+
+            # --- NOUVEAU : Sauvegarde du setting preserve_linear_output ---
+            'preserve_linear_output': bool(getattr(self, 'preserve_linear_output', False)),
+            # --- FIN NOUVEAU ---
+
             'local_solver_preference': str(getattr(self, 'local_solver_preference', 'none')),
             'astap_path': str(getattr(self, 'astap_path', "")),
             'astap_data_dir': str(getattr(self, 'astap_data_dir', "")),

--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -128,6 +128,7 @@ EN_TRANSLATIONS = {
     # --- Output Format Section ---
     'output_format_frame_title': "Output FITS Format",
     'save_as_float32_label': "Save final FITS as float32 (larger files, max precision)",
+    'preserve_linear_output_label': "Preserve linear output (skip percentile scaling)",
 
     ### NEW: Tooltips for Expert Tab ###
     'tooltip_bn_grid_size': "BN: RxC grid for background analysis. More zones (32x32) = finer local analysis, noise sensitive. Fewer (8x8) = robust stats, worse for complex gradients. Default: 16x16.",
@@ -158,6 +159,7 @@ EN_TRANSLATIONS = {
     'tooltip_low_wht_soften_px': "Soften Low WHT Mask (px): Radius of Gaussian blur applied to the binary mask of low-weight areas. Allows for a smoother transition of the correction. Range: 32-512. Default: 128.",
     # Tooltips save_as_float32
     'tooltip_save_as_float32': "If checked, the final FITS file will be saved using 32-bit floating-point numbers, preserving the maximum numerical precision from processing but resulting in larger files (approx. 2x). If unchecked (default), the file will be saved as 16-bit unsigned integers (0-65535 range after scaling from 0-1), significantly reducing file size.",
+    'tooltip_preserve_linear_output': "If enabled, skips percentile-based normalization before saving. The uint16 output will scale the raw 0-1 values directly to 0-65535.",
 
     # ... end expert tab ...
     

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -160,6 +160,7 @@ FR_TRANSLATIONS = {
     # --- Section Format de Sortie FITS ---
     'output_format_frame_title': "Format FITS de Sortie",
     'save_as_float32_label': "Sauvegarder FITS final en float32 (fichiers +gros, précision max)",
+    'preserve_linear_output_label': "Préserver l'image linéaire (ignorer la normalisation par percentiles)",
 
     
     
@@ -194,6 +195,7 @@ FR_TRANSLATIONS = {
     
     # Tooltips save flaot32
     'tooltip_save_as_float32': "Si coché, le fichier FITS final sera sauvegardé en utilisant des nombres flottants 32 bits, préservant la précision numérique maximale du traitement mais résultant en des fichiers plus volumineux (env. 2x). Si décoché (défaut), le fichier sera sauvegardé en entiers non signés 16 bits (plage 0-65535 après mise à l'échelle depuis 0-1), réduisant significativement la taille du fichier.",
+    'tooltip_preserve_linear_output': "Si activé, la normalisation par percentiles est ignorée avant la sauvegarde. La sortie uint16 sera l'échelle directe des valeurs 0-1 vers 0-65535.",
 
     
     # --- FIN NOUVEAU ---

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -292,6 +292,10 @@ class SeestarQueuedStacker:
 
         self.save_final_as_float32 = False # Par défaut, sauvegarde en uint16 (via conversion dans _save_final_stack)
         logger.debug(f"  -> Attribut self.save_final_as_float32 initialisé à: {self.save_final_as_float32}")
+        self.preserve_linear_output = False
+        logger.debug(
+            f"  -> Attribut self.preserve_linear_output initialisé à: {self.preserve_linear_output}"
+        )
         # Option de reprojection des lots intermédiaires
         self.reproject_between_batches = False
         # Liste des fichiers intermédiaires en mode Classic avec reprojection
@@ -5014,10 +5018,16 @@ class SeestarQueuedStacker:
         logger.debug("\n" + "=" * 80)
         self.update_progress(f"DEBUG QM [_save_final_stack V_SaveFinal_CorrectedDataFlow_1]: Début. Suffixe: '{output_filename_suffix}', Arrêt précoce: {stopped_early}")
         logger.debug(f"DEBUG QM [_save_final_stack V_SaveFinal_CorrectedDataFlow_1]: Début. Suffixe: '{output_filename_suffix}', Arrêt précoce: {stopped_early}")
-        
-        save_as_float32_setting = getattr(self, 'save_final_as_float32', False) 
+
+        save_as_float32_setting = getattr(self, 'save_final_as_float32', False)
+        preserve_linear_output_setting = getattr(self, 'preserve_linear_output', False)
+        # Retro-compatibilité : certaines versions utilisaient le nom
+        # `preserve_linear_output_flag`. On crée un alias pour éviter
+        # un NameError si d'anciens appels ou du code externe s'y réfèrent.
+        preserve_linear_output_flag = preserve_linear_output_setting
         self.update_progress(f"  DEBUG QM: Option de sauvegarde FITS effective (self.save_final_as_float32): {save_as_float32_setting}")
         logger.debug(f"  DEBUG QM: Option de sauvegarde FITS effective (self.save_final_as_float32): {save_as_float32_setting}")
+        logger.debug(f"  DEBUG QM: preserve_linear_output active?: {preserve_linear_output_setting}")
         
         is_reproject_mosaic_mode = (output_filename_suffix == "_mosaic_reproject" and 
                                     drizzle_final_sci_data is not None and 
@@ -5199,50 +5209,62 @@ class SeestarQueuedStacker:
             self.raw_adu_data_for_ui_histogram = None
 
         # --- Normalisation par percentiles pour obtenir final_image_normalized_for_cosmetics (0-1) ---
-        logger.debug(
-            f"  DEBUG QM [_save_final_stack]: Normalisation (0-1) par percentiles de final_image_initial_raw..."
-        )
-        data_for_percentile_norm = np.nan_to_num(final_image_initial_raw, nan=0.0).astype(np.float32)
-        if data_for_percentile_norm.ndim == 3:
-            luminance = (
-                0.299 * data_for_percentile_norm[..., 0]
-                + 0.587 * data_for_percentile_norm[..., 1]
-                + 0.114 * data_for_percentile_norm[..., 2]
-            )
-        else:
-            luminance = data_for_percentile_norm
-        finite_luminance = luminance[np.isfinite(luminance) & (luminance > 1e-9)]
-
-        if finite_luminance.size > 20:
-            bp_val = np.percentile(finite_luminance, 0.1)
-            wp_val = np.percentile(finite_luminance, 99.9)
-            if wp_val <= bp_val + 1e-7:
-                min_finite, max_finite = np.min(finite_luminance), np.max(finite_luminance)
-                if max_finite > min_finite + 1e-7:
-                    bp_val, wp_val = min_finite, max_finite
-                else:
-                    bp_val, wp_val = 0.0, max(1e-7, max_finite)
-            if wp_val <= bp_val:
-                wp_val = bp_val + 1e-7
-            final_image_normalized_for_cosmetics = (data_for_percentile_norm - bp_val) / (
-                wp_val - bp_val
-            )
+        if preserve_linear_output_setting:
             logger.debug(
-                f"  DEBUG QM [_save_final_stack]: Normalisation (0-1) basée sur percentiles. BP={bp_val:.4g}, WP={wp_val:.4g}."
+                "  DEBUG QM [_save_final_stack]: preserve_linear_output actif - saut de la normalisation par percentiles."
+            )
+            final_image_normalized_for_cosmetics = np.clip(
+                np.nan_to_num(final_image_initial_raw, nan=0.0).astype(np.float32),
+                0.0,
+                1.0,
             )
         else:
-            max_overall = np.nanmax(data_for_percentile_norm)
-            if max_overall > 1e-9:
-                final_image_normalized_for_cosmetics = data_for_percentile_norm / max_overall
+            logger.debug(
+                f"  DEBUG QM [_save_final_stack]: Normalisation (0-1) par percentiles de final_image_initial_raw..."
+            )
+            data_for_percentile_norm = np.nan_to_num(final_image_initial_raw, nan=0.0).astype(np.float32)
+            if data_for_percentile_norm.ndim == 3:
+                luminance = (
+                    0.299 * data_for_percentile_norm[..., 0]
+                    + 0.587 * data_for_percentile_norm[..., 1]
+                    + 0.114 * data_for_percentile_norm[..., 2]
+                )
             else:
-                final_image_normalized_for_cosmetics = np.zeros_like(data_for_percentile_norm)
-            logger.debug(
-                "  DEBUG QM [_save_final_stack]: Normalisation (0-1) par max (peu de données/dynamique pour percentiles)."
+                luminance = data_for_percentile_norm
+            finite_luminance = luminance[np.isfinite(luminance) & (luminance > 1e-9)]
+
+            if finite_luminance.size > 20:
+                bp_val = np.percentile(finite_luminance, 0.1)
+                wp_val = np.percentile(finite_luminance, 99.9)
+                if wp_val <= bp_val + 1e-7:
+                    min_finite, max_finite = np.min(finite_luminance), np.max(finite_luminance)
+                    if max_finite > min_finite + 1e-7:
+                        bp_val, wp_val = min_finite, max_finite
+                    else:
+                        bp_val, wp_val = 0.0, max(1e-7, max_finite)
+                if wp_val <= bp_val:
+                    wp_val = bp_val + 1e-7
+                final_image_normalized_for_cosmetics = (data_for_percentile_norm - bp_val) / (
+                    wp_val - bp_val
+                )
+                logger.debug(
+                    f"  DEBUG QM [_save_final_stack]: Normalisation (0-1) basée sur percentiles. BP={bp_val:.4g}, WP={wp_val:.4g}."
+                )
+            else:
+                max_overall = np.nanmax(data_for_percentile_norm)
+                if max_overall > 1e-9:
+                    final_image_normalized_for_cosmetics = data_for_percentile_norm / max_overall
+                else:
+                    final_image_normalized_for_cosmetics = np.zeros_like(data_for_percentile_norm)
+                logger.debug(
+                    "  DEBUG QM [_save_final_stack]: Normalisation (0-1) par max (peu de données/dynamique pour percentiles)."
+                )
+
+            final_image_normalized_for_cosmetics = np.clip(
+                final_image_normalized_for_cosmetics, 0.0, 1.0
             )
 
-        final_image_normalized_for_cosmetics = np.clip(
-            final_image_normalized_for_cosmetics, 0.0, 1.0
-        ).astype(np.float32)
+        final_image_normalized_for_cosmetics = final_image_normalized_for_cosmetics.astype(np.float32)
         logger.debug(
             f"    Range après normalisation (0-1): [{np.nanmin(final_image_normalized_for_cosmetics):.3f}, {np.nanmax(final_image_normalized_for_cosmetics):.3f}]"
         )
@@ -5621,6 +5643,7 @@ class SeestarQueuedStacker:
 
                          local_solver_preference="none",
                          save_as_float32=False,
+                         preserve_linear_output=False,
                          reproject_between_batches=False
                          ):
         logger.debug(f"!!!!!!!!!! VALEUR BRUTE ARGUMENT astap_search_radius REÇU : {astap_search_radius} !!!!!!!!!!")
@@ -5745,6 +5768,10 @@ class SeestarQueuedStacker:
 
         self.save_final_as_float32 = bool(save_as_float32)
         logger.debug(f"    [OutputFormat] self.save_final_as_float32 (attribut d'instance) mis à : {self.save_final_as_float32} (depuis argument {save_as_float32})")
+        self.preserve_linear_output = bool(preserve_linear_output)
+        logger.debug(
+            f"    [OutputFormat] self.preserve_linear_output (attribut d'instance) mis à : {self.preserve_linear_output} (depuis argument {preserve_linear_output})"
+        )
         self.reproject_between_batches = bool(reproject_between_batches)
 
         # --- FIN NOUVEAU ---


### PR DESCRIPTION
## Summary
- add `preserve_linear_output` to settings and GUI
- update QueueManager to skip percentile scaling when enabled
- add translations and README notes
- avoid NameError if old code references `preserve_linear_output_flag`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848009084bc832fa73ce4e957e4fe0f