### PR TITLE
Handle out-of-bounds pixmap

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3755,6 +3755,21 @@ class SeestarQueuedStacker:
                         f"      DEBUG QM [ProcIncrDrizLoop]: Pixmap recalc (origin=1) X range [{np.nanmin(pix_x):.2f}, {np.nanmax(pix_x):.2f}], "
                         f"Y range [{np.nanmin(pix_y):.2f}, {np.nanmax(pix_y):.2f}]"
                     )
+                    # Recompute range after origin=1 and clip if still out of bounds
+                    min_x, max_x = np.nanmin(pix_x), np.nanmax(pix_x)
+                    min_y, max_y = np.nanmin(pix_y), np.nanmax(pix_y)
+                    if (min_x < 0 or max_x >= width_out or min_y < 0 or max_y >= height_out):
+                        logger.warning(
+                            "      WARN [ProcIncrDrizLoop]: Pixmap toujours hors bornes apres origin=1, clipping."
+                        )
+                        pixmap_for_this_file[..., 0] = np.clip(pix_x, 0, width_out - 1)
+                        pixmap_for_this_file[..., 1] = np.clip(pix_y, 0, height_out - 1)
+                        pix_x = pixmap_for_this_file[..., 0]
+                        pix_y = pixmap_for_this_file[..., 1]
+                        logger.debug(
+                            f"      DEBUG QM [ProcIncrDrizLoop]: Pixmap clipped X range [{np.nanmin(pix_x):.2f}, {np.nanmax(pix_x):.2f}], "
+                            f"Y range [{np.nanmin(pix_y):.2f}, {np.nanmax(pix_y):.2f}]"
+                        )
 
                 logger.debug(f"      DEBUG QM [ProcIncrDrizLoop M81_Scale_2_Full]: Pixmap calculé pour '{current_filename_for_log}'.")
 

--- a/tests/test_pixmap_clipping.py
+++ b/tests/test_pixmap_clipping.py
@@ -1,0 +1,24 @@
+import numpy as np
+from drizzle.resample import Drizzle
+
+
+def test_pixmap_clipping_keeps_weights():
+    shape = (10, 10)
+    img = np.ones((2, 2), dtype=np.float32)
+
+    # Pixel map shifted out of range by -0.5 in both axes
+    pixmap = np.dstack(
+        (
+            np.array([[-0.5, 0.5], [-0.5, 0.5]], dtype=np.float32),
+            np.array([[-0.5, -0.5], [0.5, 0.5]], dtype=np.float32),
+        )
+    )
+
+    # Clip coordinates to valid output bounds
+    pixmap[..., 0] = np.clip(pixmap[..., 0], 0, shape[1] - 1)
+    pixmap[..., 1] = np.clip(pixmap[..., 1], 0, shape[0] - 1)
+
+    driz = Drizzle(out_shape=shape, fillval=0.0)
+    driz.add_image(img, pixmap=pixmap, exptime=1.0, weight_map=np.ones_like(img))
+
+    assert np.sum(driz.out_wht) > 0


### PR DESCRIPTION
## Summary
- recompute pixmap ranges after using `origin=1`
- clip remaining out-of-bound pixels and warn
- test pixmap clipping keeps drizzle weights non-zero

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c92e2fc8832fba20165a155634af