### PR TITLE
Fix histogram refresh after stacking

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -3745,8 +3745,8 @@ class SeestarStackerGUI:
                         total_batches=self.preview_total_batches,
                     )
 
-                if hasattr(self, 'histogram_widget') and self.histogram_widget:
-                    self.histogram_widget.update_histogram(self._temp_data_for_final_histo)
+                    if hasattr(self, 'histogram_widget') and self.histogram_widget:
+                        self.histogram_widget.update_histogram(self.current_preview_data)
 
                 if self.current_stack_header:
                     self.update_image_info(self.current_stack_header)


### PR DESCRIPTION
## Summary
- ensure histogram refreshes after loading final stack

## Testing
- `pytest -q`
- `pytest tests/test_mosaic_worker.py::test_resolve_after_crop -q`

------
https://chatgpt.com/codex/tasks/task_e_6849656c2700832fa3d79079837fe0ad