### PR TITLE
Fix fallback WCS reprojection indentation

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3480,92 +3480,92 @@ class SeestarQueuedStacker:
                     except Exception:
                         pass
 
-                if self.reproject_between_batches and self.reference_wcs_object:
-                    if batch_wcs is None:
-                        try:
-                            hdr_wcs = WCS(stack_info_header, naxis=2)
-                            if hdr_wcs.is_celestial:
-                                M_fallback = self._calculate_M_from_wcs(
-                                    self.reference_wcs_object,
-                                    hdr_wcs,
-                                    stacked_batch_data_np.shape[:2],
-                                )
-                                if M_fallback is not None:
-                                    A = np.asarray(M_fallback, dtype=float)[:2, :2]
-                                    t = np.asarray(M_fallback, dtype=float)[:2, 2]
-                                    approx_wcs = self.reference_wcs_object.deepcopy()
-                                    try:
-                                        A_inv = np.linalg.inv(A)
-                                    except np.linalg.LinAlgError:
-                                        approx_wcs = None
-                                    else:
-                                        if getattr(approx_wcs.wcs, "cd", None) is not None:
-                                            approx_wcs.wcs.cd = approx_wcs.wcs.cd @ A_inv
-                                        elif getattr(approx_wcs.wcs, "pc", None) is not None and getattr(approx_wcs.wcs, "cdelt", None) is not None:
-                                            cd_matrix = approx_wcs.wcs.pc @ np.diag(approx_wcs.wcs.cdelt)
-                                            cd_matrix = cd_matrix @ A_inv
-                                            approx_wcs.wcs.pc = np.identity(2)
-                                            approx_wcs.wcs.cdelt = [cd_matrix[0, 0], cd_matrix[1, 1]]
-                                        approx_wcs.wcs.crpix = A @ approx_wcs.wcs.crpix + t
-                                        approx_wcs.pixel_shape = (
-                                            stacked_batch_data_np.shape[1],
-                                            stacked_batch_data_np.shape[0],
-                                        )
-                                    if approx_wcs is not None:
-                                        batch_wcs = approx_wcs
-                                        self.update_progress(
-                                            f"⚠️ [FallbackWCS] WCS approximatif utilisé pour lot {current_batch_num}",
-                                            "WARN",
-                                        )
-                        except Exception as e:
-                            self.update_progress(
-                                f"⚠️ [FallbackWCS] Impossible d'estimer WCS lot {current_batch_num}: {e}",
-                                "WARN",
+            if self.reproject_between_batches and self.reference_wcs_object:
+                if batch_wcs is None:
+                    try:
+                        hdr_wcs = WCS(stack_info_header, naxis=2)
+                        if hdr_wcs.is_celestial:
+                            M_fallback = self._calculate_M_from_wcs(
+                                self.reference_wcs_object,
+                                hdr_wcs,
+                                stacked_batch_data_np.shape[:2],
                             )
-                    if batch_wcs is not None:
-                        try:
-                            self.update_progress(
-                                f"➡️ [Reproject] Entrée dans reproject pour le batch {current_batch_num}/{total_batches_est}",
-                                "INFO_DETAIL",
-                            )
-                            stacked_batch_data_np, _ = self._reproject_to_reference(
-                                stacked_batch_data_np, batch_wcs
-                            )
-                            batch_coverage_map_2d, _ = self._reproject_to_reference(
-                                batch_coverage_map_2d, batch_wcs
-                            )
-                            batch_wcs = self.reference_wcs_object
-                            self.update_progress(
-                                f"✅ [Reproject] Batch {current_batch_num}/{total_batches_est} reprojecté vers référence (shape {self.memmap_shape[:2]})",
-                                "INFO_DETAIL",
-                            )
-                        except Exception as e:
-                            self.update_progress(
-                                f"⚠️ [Reproject] Batch {current_batch_num} ignoré : {type(e).__name__}: {e}",
-                                "WARN",
-                            )
+                            if M_fallback is not None:
+                                A = np.asarray(M_fallback, dtype=float)[:2, :2]
+                                t = np.asarray(M_fallback, dtype=float)[:2, 2]
+                                approx_wcs = self.reference_wcs_object.deepcopy()
+                                try:
+                                    A_inv = np.linalg.inv(A)
+                                except np.linalg.LinAlgError:
+                                    approx_wcs = None
+                                else:
+                                    if getattr(approx_wcs.wcs, "cd", None) is not None:
+                                        approx_wcs.wcs.cd = approx_wcs.wcs.cd @ A_inv
+                                    elif getattr(approx_wcs.wcs, "pc", None) is not None and getattr(approx_wcs.wcs, "cdelt", None) is not None:
+                                        cd_matrix = approx_wcs.wcs.pc @ np.diag(approx_wcs.wcs.cdelt)
+                                        cd_matrix = cd_matrix @ A_inv
+                                        approx_wcs.wcs.pc = np.identity(2)
+                                        approx_wcs.wcs.cdelt = [cd_matrix[0, 0], cd_matrix[1, 1]]
+                                    approx_wcs.wcs.crpix = A @ approx_wcs.wcs.crpix + t
+                                    approx_wcs.pixel_shape = (
+                                        stacked_batch_data_np.shape[1],
+                                        stacked_batch_data_np.shape[0],
+                                    )
+                                if approx_wcs is not None:
+                                    batch_wcs = approx_wcs
+                                    self.update_progress(
+                                        f"⚠️ [FallbackWCS] WCS approximatif utilisé pour lot {current_batch_num}",
+                                        "WARN",
+                                    )
+                    except Exception as e:
+                        self.update_progress(
+                            f"⚠️ [FallbackWCS] Impossible d'estimer WCS lot {current_batch_num}: {e}",
+                            "WARN",
+                        )
+                if batch_wcs is not None:
+                    try:
+                        self.update_progress(
+                            f"➡️ [Reproject] Entrée dans reproject pour le batch {current_batch_num}/{total_batches_est}",
+                            "INFO_DETAIL",
+                        )
+                        stacked_batch_data_np, _ = self._reproject_to_reference(
+                            stacked_batch_data_np, batch_wcs
+                        )
+                        batch_coverage_map_2d, _ = self._reproject_to_reference(
+                            batch_coverage_map_2d, batch_wcs
+                        )
+                        batch_wcs = self.reference_wcs_object
+                        self.update_progress(
+                            f"✅ [Reproject] Batch {current_batch_num}/{total_batches_est} reprojecté vers référence (shape {self.memmap_shape[:2]})",
+                            "INFO_DETAIL",
+                        )
+                    except Exception as e:
+                        self.update_progress(
+                            f"⚠️ [Reproject] Batch {current_batch_num} ignoré : {type(e).__name__}: {e}",
+                            "WARN",
+                        )
 
-                logger.debug(f"DEBUG QM [_process_completed_batch]: Appel à _combine_batch_result pour lot #{current_batch_num}...")
-                self._combine_batch_result(
+            logger.debug(f"DEBUG QM [_process_completed_batch]: Appel à _combine_batch_result pour lot #{current_batch_num}...")
+            self._combine_batch_result(
+                stacked_batch_data_np,
+                stack_info_header,
+                batch_coverage_map_2d,
+                batch_wcs,
+            )
+
+            if self.reproject_between_batches:
+                sci_p, wht_p_list = self._save_and_solve_classic_batch(
                     stacked_batch_data_np,
-                    stack_info_header,
                     batch_coverage_map_2d,
-                    batch_wcs,
+                    stack_info_header,
+                    current_batch_num,
                 )
+                if sci_p and wht_p_list:
+                    self.intermediate_classic_batch_files.append((sci_p, wht_p_list))
 
-                if self.reproject_between_batches:
-                    sci_p, wht_p_list = self._save_and_solve_classic_batch(
-                        stacked_batch_data_np,
-                        batch_coverage_map_2d,
-                        stack_info_header,
-                        current_batch_num,
-                    )
-                    if sci_p and wht_p_list:
-                        self.intermediate_classic_batch_files.append((sci_p, wht_p_list))
-
-                if not self.drizzle_active_session:
-                    logger.debug("DEBUG QM [_process_completed_batch]: Appel à _update_preview_sum_w après accumulation lot classique...")
-                    self._update_preview_sum_w()
+            if not self.drizzle_active_session:
+                logger.debug("DEBUG QM [_process_completed_batch]: Appel à _update_preview_sum_w après accumulation lot classique...")
+                self._update_preview_sum_w()
             
         else: # _stack_batch a échoué ou n'a rien retourné de valide
             # Le nombre d'images du lot qui a échoué à l'étape _stack_batch


### PR DESCRIPTION
## Summary
- fix indentation for fallback WCS reprojection logic so it executes when `reproject_between_batches` is enabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68497fce492c832fbde1cf512405a703