### PR TITLE
Add ASTAP solver downsample & sensitivity support

### DIFF
--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -611,6 +611,8 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         astap_radius = self.astap_search_radius_var.get()
         astap_downsample = self.astap_downsample_var.get()
         astap_sensitivity = self.astap_sensitivity_var.get()
+        self.parent_gui.settings.astap_downsample = astap_downsample
+        self.parent_gui.settings.astap_sensitivity = astap_sensitivity
         cluster_threshold = self.cluster_threshold_var.get()
         local_ansvr_path = self.local_ansvr_path_var.get().strip()
         ansvr_host_port = self.ansvr_host_port_var.get().strip()

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4318,6 +4318,8 @@ class SeestarStackerGUI:
             "local_ansvr_path": self.settings.local_ansvr_path,
             "local_solver_preference": self.settings.local_solver_preference,
             "astap_search_radius": self.settings.astap_search_radius,
+            "astap_downsample": self.settings.astap_downsample,
+            "astap_sensitivity": self.settings.astap_sensitivity,
             "save_as_float32": self.settings.save_final_as_float32,
             "preserve_linear_output": self.settings.preserve_linear_output,
             "reproject_between_batches": self.settings.reproject_between_batches,

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -506,6 +506,8 @@ class SettingsManager:
         defaults_dict['astap_path'] = ""
         defaults_dict['astap_data_dir'] = ""
         defaults_dict['astap_search_radius'] = 3.0
+        defaults_dict['astap_downsample'] = 1
+        defaults_dict['astap_sensitivity'] = 100
         defaults_dict['use_radec_hints'] = False
         defaults_dict['local_ansvr_path'] = ""
         defaults_dict['ansvr_host_port'] = '127.0.0.1:8080'

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1660,6 +1660,8 @@ class SeestarQueuedStacker:
                 'astap_path': self.astap_path,
                 'astap_data_dir': self.astap_data_dir,
                 'astap_search_radius': self.astap_search_radius,
+                'astap_downsample': self.astap_downsample,
+                'astap_sensitivity': self.astap_sensitivity,
                 'local_ansvr_path': self.local_ansvr_path,
                 'scale_est_arcsec_per_pix': self.reference_pixel_scale_arcsec, # Peut être None au premier passage
                 'scale_tolerance_percent': 20,
@@ -3210,7 +3212,21 @@ class SeestarQueuedStacker:
                 if not fa_success and self.use_wcs_fallback_for_mosaic: 
                     align_method_log_msg += "_Fallback_Attempted" 
                     if self.astrometry_solver:
-                        solver_settings_for_panel_fallback = { 'local_solver_preference': self.local_solver_preference, 'api_key': self.api_key, 'astap_path': self.astap_path, 'astap_data_dir': self.astap_data_dir,'astap_search_radius': self.astap_search_radius,'local_ansvr_path': self.local_ansvr_path,'scale_est_arcsec_per_pix': self.reference_pixel_scale_arcsec,'scale_tolerance_percent': 20, 'ansvr_timeout_sec': getattr(self, 'ansvr_timeout_sec', 120),'astap_timeout_sec': getattr(self, 'astap_timeout_sec', 120),'astrometry_net_timeout_sec': getattr(self, 'astrometry_net_timeout_sec', 300)}
+                        solver_settings_for_panel_fallback = {
+                            'local_solver_preference': self.local_solver_preference,
+                            'api_key': self.api_key,
+                            'astap_path': self.astap_path,
+                            'astap_data_dir': self.astap_data_dir,
+                            'astap_search_radius': self.astap_search_radius,
+                            'astap_downsample': self.astap_downsample,
+                            'astap_sensitivity': self.astap_sensitivity,
+                            'local_ansvr_path': self.local_ansvr_path,
+                            'scale_est_arcsec_per_pix': self.reference_pixel_scale_arcsec,
+                            'scale_tolerance_percent': 20,
+                            'ansvr_timeout_sec': getattr(self, 'ansvr_timeout_sec', 120),
+                            'astap_timeout_sec': getattr(self, 'astap_timeout_sec', 120),
+                            'astrometry_net_timeout_sec': getattr(self, 'astrometry_net_timeout_sec', 300)
+                        }
                         wcs_panel_solved_by_solver = None
                         try: wcs_panel_solved_by_solver = self.astrometry_solver.solve(file_path, header_final_pour_retour, solver_settings_for_panel_fallback,True)
                         except Exception as e_s: align_method_log_msg += f"_SolveError_{type(e_s).__name__}"
@@ -3228,7 +3244,21 @@ class SeestarQueuedStacker:
             elif solve_astrometry_for_this_file and self.is_mosaic_run and self.mosaic_alignment_mode == "astrometry_per_panel":
                 align_method_log_msg = "Astrometry_Per_Panel_Attempted"
                 if self.astrometry_solver:
-                    solver_settings_for_this_panel = { 'local_solver_preference': self.local_solver_preference, 'api_key': self.api_key, 'astap_path': self.astap_path, 'astap_data_dir': self.astap_data_dir, 'astap_search_radius': self.astap_search_radius, 'local_ansvr_path': self.local_ansvr_path, 'scale_est_arcsec_per_pix': self.reference_pixel_scale_arcsec,'scale_tolerance_percent': 20, 'ansvr_timeout_sec': getattr(self, 'ansvr_timeout_sec', 120),'astap_timeout_sec': getattr(self, 'astap_timeout_sec', 120),'astrometry_net_timeout_sec': getattr(self, 'astrometry_net_timeout_sec', 300)}
+                    solver_settings_for_this_panel = {
+                        'local_solver_preference': self.local_solver_preference,
+                        'api_key': self.api_key,
+                        'astap_path': self.astap_path,
+                        'astap_data_dir': self.astap_data_dir,
+                        'astap_search_radius': self.astap_search_radius,
+                        'astap_downsample': self.astap_downsample,
+                        'astap_sensitivity': self.astap_sensitivity,
+                        'local_ansvr_path': self.local_ansvr_path,
+                        'scale_est_arcsec_per_pix': self.reference_pixel_scale_arcsec,
+                        'scale_tolerance_percent': 20,
+                        'ansvr_timeout_sec': getattr(self, 'ansvr_timeout_sec', 120),
+                        'astap_timeout_sec': getattr(self, 'astap_timeout_sec', 120),
+                        'astrometry_net_timeout_sec': getattr(self, 'astrometry_net_timeout_sec', 300)
+                    }
                     wcs_final_pour_retour = self.astrometry_solver.solve(file_path, header_final_pour_retour, solver_settings_for_this_panel, True)
                     if wcs_final_pour_retour and wcs_final_pour_retour.is_celestial: align_method_log_msg = "Astrometry_Per_Panel_Success"; matrice_M_calculee = np.array([[1.,0.,0.],[0.,1.,0.]], dtype=np.float32) 
                     else: align_method_log_msg = "Astrometry_Per_Panel_Fail"; wcs_final_pour_retour = None; matrice_M_calculee = None
@@ -3439,6 +3469,8 @@ class SeestarQueuedStacker:
                         "astap_path": self.astap_path,
                         "astap_data_dir": self.astap_data_dir,
                         "astap_search_radius": self.astap_search_radius,
+                        "astap_downsample": self.astap_downsample,
+                        "astap_sensitivity": self.astap_sensitivity,
                         "local_ansvr_path": self.local_ansvr_path,
                         "scale_est_arcsec_per_pix": getattr(self, "reference_pixel_scale_arcsec", None),
                         "scale_tolerance_percent": 20,
@@ -5115,6 +5147,8 @@ class SeestarQueuedStacker:
             "astap_path": self.astap_path,
             "astap_data_dir": self.astap_data_dir,
             "astap_search_radius": self.astap_search_radius,
+            "astap_downsample": self.astap_downsample,
+            "astap_sensitivity": self.astap_sensitivity,
             "local_ansvr_path": self.local_ansvr_path,
             "scale_est_arcsec_per_pix": getattr(self, "reference_pixel_scale_arcsec", None),
             "scale_tolerance_percent": 20,
@@ -5899,6 +5933,9 @@ class SeestarQueuedStacker:
                          local_ansvr_path="",
                          astap_search_radius=3.0,
 
+                         astap_downsample=1,
+                         astap_sensitivity=100,
+
                          local_solver_preference="none",
                          save_as_float32=False,
                          preserve_linear_output=False,
@@ -5967,13 +6004,17 @@ class SeestarQueuedStacker:
         self.local_solver_preference = str(local_solver_preference) 
         self.astap_path = str(astap_path)
         self.astap_data_dir = str(astap_data_dir)
-        self.astap_search_radius = float(astap_search_radius) 
+        self.astap_search_radius = float(astap_search_radius)
+        self.astap_downsample = int(astap_downsample)
+        self.astap_sensitivity = int(astap_sensitivity)
         self.local_ansvr_path = str(local_ansvr_path)
         
         logger.debug(f"    [Solver Settings sur self via start_processing args] Pref: '{self.local_solver_preference}'")
         logger.debug(f"    [Solver Settings sur self via start_processing args] ASTAP Path: '{self.astap_path}'")
         logger.debug(f"    [Solver Settings sur self via start_processing args] ASTAP Data Dir: '{self.astap_data_dir}'")
         logger.debug(f"    [Solver Settings sur self via start_processing args] ASTAP Search Radius: {self.astap_search_radius}")
+        logger.debug(f"    [Solver Settings sur self via start_processing args] ASTAP Downsample: {self.astap_downsample}")
+        logger.debug(f"    [Solver Settings sur self via start_processing args] ASTAP Sensitivity: {self.astap_sensitivity}")
         logger.debug(f"    [Solver Settings sur self via start_processing args] Ansvr Path: '{self.local_ansvr_path}'")
         
         try:
@@ -6164,6 +6205,8 @@ class SeestarQueuedStacker:
                     "astap_path": self.astap_path,
                     "astap_data_dir": self.astap_data_dir,
                     "astap_search_radius": self.astap_search_radius,
+                    "astap_downsample": self.astap_downsample,
+                    "astap_sensitivity": self.astap_sensitivity,
                     "local_ansvr_path": self.local_ansvr_path,
                     "scale_est_arcsec_per_pix": self.reference_pixel_scale_arcsec, 
                     "scale_tolerance_percent": 20, 

--- a/tests/test_worker_incremental_drizzle.py
+++ b/tests/test_worker_incremental_drizzle.py
@@ -67,6 +67,8 @@ def _make_worker(tmp_path):
     obj.update_progress = lambda *a, **k: None
     obj.local_solver_preference = "none"
     obj.astap_search_radius = 1.0
+    obj.astap_downsample = 1
+    obj.astap_sensitivity = 100
     obj.reference_pixel_scale_arcsec = 1.0
     obj.astap_path = ""
     obj.astap_data_dir = ""


### PR DESCRIPTION
## Summary
- allow ASTAP downsample and sensitivity settings
- forward the values from GUI to queue manager
- pass them to the astrometry solver
- fix incremental drizzle test to set defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849983cf990832f9b0250bf851496d8