### PR TITLE
Use ZeMosaic ASTAP solver in classic stacking

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -5159,7 +5159,31 @@ class SeestarQueuedStacker:
         }
 
         self.update_progress(f"   [ASTAP] Solve {os.path.basename(fits_path)}…")
-        wcs = solve_image_wcs(fits_path, header, solver_settings, update_header_with_solution=True)
+        try:
+            from zemosaic import zemosaic_astrometry
+
+            def _pcb(msg, prog=None, lvl=None):
+                self.update_progress(msg, prog)
+
+            wcs = zemosaic_astrometry.solve_with_astap(
+                image_fits_path=fits_path,
+                original_fits_header=header,
+                astap_exe_path=self.astap_path,
+                astap_data_dir=self.astap_data_dir,
+                search_radius_deg=self.astap_search_radius,
+                downsample_factor=self.astap_downsample,
+                sensitivity=self.astap_sensitivity,
+                timeout_sec=getattr(self, "astap_timeout_sec", 120),
+                update_original_header_in_place=True,
+                progress_callback=_pcb,
+            )
+        except Exception:
+            wcs = solve_image_wcs(
+                fits_path,
+                header,
+                solver_settings,
+                update_header_with_solution=True,
+            )
         if wcs is None:
             self.update_progress("   [ASTAP] Échec résolution", "WARN")
             return False


### PR DESCRIPTION
## Summary
- delegate ASTAP solving of classic batches to `zemosaic_astrometry.solve_with_astap`
- fall back to existing solver if import fails

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'drizzle')*

------
https://chatgpt.com/codex/tasks/task_e_6849a1eb135c832fb90217b481e4d720