### PR TITLE
Use local stacking instead of ZeMosaic

### DIFF
--- a/seestar/core/__init__.py
+++ b/seestar/core/__init__.py
@@ -17,6 +17,7 @@ from .weights import (
     _calculate_image_weights_noise_variance,
     _calculate_image_weights_noise_fwhm,
 )
+from .simple_stacker import create_master_tile as create_master_tile_simple
 
 # Liste initiale des éléments à exporter
 __all__ = [
@@ -31,7 +32,8 @@ __all__ = [
     'check_cupy_cuda',        # Exposer la fonction de vérification CuPy
     'SeestarAligner',         # L'aligneur astroalign
     '_calculate_image_weights_noise_variance',
-    '_calculate_image_weights_noise_fwhm'
+    '_calculate_image_weights_noise_fwhm',
+    'create_master_tile_simple'
 ]
 
 # Tentative d'importation du nouvel aligneur local

--- a/seestar/core/simple_stacker.py
+++ b/seestar/core/simple_stacker.py
@@ -1,0 +1,65 @@
+import os
+import numpy as np
+from astropy.io import fits
+
+
+def create_master_tile(
+    seestar_stack_group_info,
+    tile_id,
+    output_temp_dir,
+    stack_norm_method="none",
+    stack_weight_method="none",
+    stack_reject_algo="none",
+    stack_kappa_low=3.0,
+    stack_kappa_high=3.0,
+    parsed_winsor_limits=(0.05, 0.05),
+    stack_final_combine="mean",
+    apply_radial_weight=False,
+    radial_feather_fraction=0.8,
+    radial_shape_power=2.0,
+    min_radial_weight_floor=0.0,
+    astap_exe_path_global="",
+    astap_data_dir_global="",
+    astap_search_radius_global=0.0,
+    astap_downsample_global=0,
+    astap_sensitivity_global=0,
+    astap_timeout_seconds_global=0,
+    progress_callback=None,
+):
+    """Simplified local replacement for ZeMosaic's ``create_master_tile``.
+
+    It loads preprocessed image caches from ``seestar_stack_group_info`` and
+    stacks them using a straightforward mean combine. Only a subset of the
+    original parameters are currently honoured.
+    """
+    images = []
+    for info in seestar_stack_group_info:
+        path = info.get("path_preprocessed_cache")
+        if not path or not os.path.exists(path):
+            if progress_callback:
+                progress_callback(f"⚠️ Cache manquant pour {path}", None)
+            continue
+        try:
+            img = np.load(path)
+            if img.dtype != np.float32:
+                img = img.astype(np.float32)
+            images.append(img)
+        except Exception as exc:
+            if progress_callback:
+                progress_callback(f"⚠️ Lecture échouée {path}: {exc}", None)
+    if not images:
+        if progress_callback:
+            progress_callback("❌ Aucune image valide pour create_master_tile", None)
+        return None, None
+
+    data_stack = np.stack(images, axis=0)
+    stacked = np.nanmean(data_stack, axis=0).astype(np.float32)
+
+    hdr = fits.Header()
+    hdr["NIMAGES"] = (len(images), "Images combined")
+
+    os.makedirs(output_temp_dir, exist_ok=True)
+    out_path = os.path.join(output_temp_dir, f"master_tile_{tile_id:03d}.fits")
+    fits.writeto(out_path, np.moveaxis(stacked, -1, 0), hdr, overwrite=True)
+
+    return out_path, None

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4824,7 +4824,7 @@ class SeestarQueuedStacker:
         stacked_batch_data_np = None
         stack_info_header = None
 
-        from zemosaic.zemosaic_worker import create_master_tile
+        from seestar.core import create_master_tile_simple as create_master_tile
 
         if all_have_wcs:
             tile_path, _ = create_master_tile(

--- a/tests/test_queue_manager_reproject.py
+++ b/tests/test_queue_manager_reproject.py
@@ -223,9 +223,9 @@ def test_stack_batch_uses_master_tile_when_all_have_wcs(tmp_path, monkeypatch):
         fits.writeto(p, data, hdr, overwrite=True)
         return str(p), {}
 
-    import zemosaic.zemosaic_worker as worker
+    import seestar.core as sc
 
-    monkeypatch.setattr(worker, "create_master_tile", fake_create_master_tile)
+    monkeypatch.setattr(sc, "create_master_tile_simple", fake_create_master_tile)
 
     obj = qm.SeestarQueuedStacker()
     obj.update_progress = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- add `simple_stacker.create_master_tile` as lightweight replacement for ZeMosaic stacker
- export `create_master_tile_simple` from core package
- use new local stacker in `queue_manager._stack_batch`
- adjust tests to patch new entry point

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849dd59d454832fb06d4d55da994568