### PR TITLE
Fix ASTAP WCS parsing

### DIFF
--- a/seestar/alignment/astrometry_solver.py
+++ b/seestar/alignment/astrometry_solver.py
@@ -1072,7 +1072,16 @@ class AstrometrySolver:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", FITSFixedWarning)
                 wcs_obj = WCS(wcs_header_from_text, naxis=2, relax=True)  # relax=True pour accepter les mots-clés non standards
-            
+
+            if wcs_obj:
+                # Vérifier la présence des mots-clés essentiels et compléter si nécessaire
+                if not wcs_header_from_text.get("CTYPE1") or not wcs_header_from_text.get("CTYPE2"):
+                    wcs_obj.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+                if not wcs_header_from_text.get("CUNIT1") or not wcs_header_from_text.get("CUNIT2"):
+                    wcs_obj.wcs.cunit = ["deg", "deg"]
+                if not (wcs_header_from_text.get("CRVAL1") and wcs_header_from_text.get("CRVAL2")):
+                    self._log("CRVAL manquant dans le fichier WCS.", "WARN")
+
             if wcs_obj and wcs_obj.is_celestial:
                 # Important: définir la taille de l'image à laquelle ce WCS s'applique
                 # wcs_obj.pixel_shape attend (nx, ny) soit (largeur, hauteur)

--- a/tests/test_astrometry_solver.py
+++ b/tests/test_astrometry_solver.py
@@ -78,6 +78,35 @@ def test_parse_wcs_with_nonstandard_keywords(tmp_path):
     assert parsed.pixel_shape == (10, 10)
 
 
+def test_parse_astap_wcs_file(tmp_path):
+    solver = AstrometrySolver()
+
+    wcs_header = """
+NAXIS   =                    2
+NAXIS1  =                   10
+NAXIS2  =                   10
+CRPIX1  =                    5
+CRPIX2  =                    5
+CD1_1   =        -1.0E-04
+CD1_2   =         0.0E0
+CD2_1   =         0.0E0
+CD2_2   =         1.0E-04
+CRVAL1  =                10.0
+CRVAL2  =               -10.0
+CTYPE1  = 'RA---TAN'
+CTYPE2  = 'DEC--TAN'
+"""
+
+    wcs_path = tmp_path / "sample_astap.wcs"
+    wcs_path.write_text(wcs_header.strip() + "\n")
+
+    parsed = solver._parse_wcs_file_content(str(wcs_path), (10, 10))
+
+    assert parsed is not None
+    assert parsed.is_celestial
+    assert parsed.pixel_shape == (10, 10)
+
+
 def test_default_radius_used_when_missing(tmp_path, monkeypatch):
     """solve() should fall back to ASTAP_DEFAULT_SEARCH_RADIUS."""
     img = np.ones((10, 10), dtype=np.float32)


### PR DESCRIPTION
## Summary
- ensure CTYPE/CUNIT defaults so the parsed WCS is celestial
- add regression test for ASTAP `.wcs` files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e2c7f514832fab44a811275311c7