### PR TITLE
Fix reference WCS passing

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -2157,7 +2157,7 @@ class SeestarQueuedStacker:
                                     current_batch_items_with_masks_for_stack_batch,
                                     self.stacked_batches_count,
                                     self.total_batches_estimated,
-                                    self.reference_wcs_object,  # reference WCS
+                                    self.reference_wcs_object,  # reference WCS (argument obligatoire)
                                 )
 
                             current_batch_items_with_masks_for_stack_batch = []  # Vider le lot
@@ -2350,7 +2350,7 @@ class SeestarQueuedStacker:
                         current_batch_items_with_masks_for_stack_batch,
                         self.stacked_batches_count,
                         self.total_batches_estimated,
-                        self.reference_wcs_object,  # reference WCS
+                        self.reference_wcs_object,  # reference WCS (argument obligatoire)
                     )
 
                     current_batch_items_with_masks_for_stack_batch = []


### PR DESCRIPTION
## Summary
- clarify the reference WCS parameter when calling `_process_completed_batch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abd750100832f98037cb52df784d2