### PR TITLE
Add classic reproject final stack mode

### DIFF
--- a/tests/test_preserve_linear_output.py
+++ b/tests/test_preserve_linear_output.py
@@ -99,6 +99,9 @@ def test_preserve_linear_output(tmp_path, monkeypatch):
         lambda self, filename, **k: None,
     )
     d = Dummy()
+    d.reproject_between_batches = False
+    d.cumulative_sum_memmap = None
+    d.cumulative_wht_memmap = None
     d.output_folder = str(tmp_path)
     d.output_filename = "result.fit"
     d.images_in_cumulative_stack = 1


### PR DESCRIPTION
## Summary
- support classic stacking with inter-batch reprojection in `_save_final_stack`
- ensure mode detection uses memmap availability and new flag
- add unit test covering classic reproject path
- adjust test stubs for new attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad278f47c832fa8200e33a0dc8a6a