### PR TITLE
Refactor incremental reprojection accumulation

### DIFF
--- a/seestar/core/incremental_reprojection.py
+++ b/seestar/core/incremental_reprojection.py
@@ -7,7 +7,7 @@ from .reprojection import reproject_to_reference_wcs
 
 
 def initialize_master(batch_img: np.ndarray, batch_cov: np.ndarray, ref_wcs: WCS):
-    """Return initial master stack and coverage map.
+    """Return initial weighted sum and coverage map.
 
     Parameters
     ----------
@@ -20,47 +20,48 @@ def initialize_master(batch_img: np.ndarray, batch_cov: np.ndarray, ref_wcs: WCS
     """
     if batch_img is None or batch_cov is None:
         raise ValueError("batch_img and batch_cov are required")
-    master_img = batch_img.astype(np.float32, copy=True)
-    master_cov = batch_cov.astype(np.float32, copy=True)
-    return master_img, master_cov
+    batch_img_f = batch_img.astype(np.float32, copy=True)
+    batch_cov_f = batch_cov.astype(np.float32, copy=True)
+
+    if batch_img_f.ndim == 3:
+        master_sum = batch_img_f * batch_cov_f[..., None]
+    else:
+        master_sum = batch_img_f * batch_cov_f
+
+    master_cov = batch_cov_f
+    return master_sum, master_cov
 
 
 def reproject_and_combine(
-    master_img: np.ndarray,
+    master_sum: np.ndarray,
     master_cov: np.ndarray,
     batch_img: np.ndarray,
     batch_cov: np.ndarray,
     batch_wcs: WCS,
     ref_wcs: WCS,
 ):
-    """Reproject ``batch_img`` to ``ref_wcs`` and combine with current master.
+    """Reproject ``batch_img`` to ``ref_wcs`` and accumulate its weighted signal."""
 
-    The combination uses weighted averaging based on the coverage maps.
-    """
     if batch_wcs is None or ref_wcs is None or ref_wcs.pixel_shape is None:
-        return master_img, master_cov
+        return master_sum, master_cov
 
     target_shape = (ref_wcs.pixel_shape[1], ref_wcs.pixel_shape[0])
     reproj_img = reproject_to_reference_wcs(batch_img, batch_wcs, ref_wcs, target_shape)
     reproj_cov = reproject_to_reference_wcs(batch_cov, batch_wcs, ref_wcs, target_shape)
 
-    master_img = master_img.astype(np.float32, copy=False)
+    master_sum = master_sum.astype(np.float32, copy=False)
     master_cov = master_cov.astype(np.float32, copy=False)
     reproj_img = reproj_img.astype(np.float32, copy=False)
     reproj_cov = reproj_cov.astype(np.float32, copy=False)
 
-    weight_total = master_cov + reproj_cov
-    weight_total_safe = np.maximum(weight_total, 1e-9)
-
-    if master_img.ndim == 3:
-        master_img = (
-            master_img * master_cov[..., None] + reproj_img * reproj_cov[..., None]
-        ) / weight_total_safe[..., None]
+    if master_sum.ndim == 3:
+        master_sum += reproj_img * reproj_cov[..., None]
     else:
-        master_img = (master_img * master_cov + reproj_img * reproj_cov) / weight_total_safe
+        master_sum += reproj_img * reproj_cov
 
-    master_cov = weight_total
-    master_img = np.nan_to_num(master_img, nan=0.0, posinf=0.0, neginf=0.0)
+    master_cov += reproj_cov
+
+    master_sum = np.nan_to_num(master_sum, nan=0.0, posinf=0.0, neginf=0.0)
     master_cov = np.nan_to_num(master_cov, nan=0.0, posinf=0.0, neginf=0.0)
 
-    return master_img.astype(np.float32), master_cov.astype(np.float32)
+    return master_sum.astype(np.float32), master_cov.astype(np.float32)


### PR DESCRIPTION
## Summary
- track weighted sums instead of means during incremental reprojection
- compute on-the-fly average for previews and final output
- rename `master_stack` to `master_sum`

## Testing
- `pytest -q` *(fails: test_resolve_after_crop, test_solver_header_values_no_wcs, test_use_sidecar_wcs, test_output_scale_warning_and_adjust, test_grid_uses_resolved_wcs)*

------
https://chatgpt.com/codex/tasks/task_e_684ad8155930832f93de9bb07530cfb8