### PR TITLE
Dynamic grid applies to accumulation canvas

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1209,7 +1209,7 @@ class SeestarQueuedStacker:
             f"DEBUG (Backend _calculate_final_mosaic_grid - Dynamic Box): Appel avec {num_wcs} WCS."
         )
         self.update_progress(
-            f"📐 Calcul de la grille de sortie portrait ({num_wcs} WCS)..."
+            f"📐 Calcul de la grille de sortie dynamique ({num_wcs} WCS)..."
         )
         if num_wcs == 0:
             return None, None
@@ -1281,7 +1281,10 @@ class SeestarQueuedStacker:
         output_wcs = WCS(naxis=2)
         output_wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
         output_wcs.wcs.crval = [center_ra, center_dec]
-        output_wcs.wcs.crpix = [nw / 2.0, nh / 2.0]
+        # Center the mosaic so that the lower-left corner of the bounding box
+        # maps to pixel (1, 1). This avoids negative pixel coordinates once
+        # images are reprojected onto the final canvas.
+        output_wcs.wcs.crpix = [-minx + 1.0, -miny + 1.0]
         cos_t = np.cos(np.deg2rad(theta))
         sin_t = np.sin(np.deg2rad(theta))
         output_wcs.wcs.cd = final_pixel_scale_deg * np.array([[-cos_t, sin_t], [sin_t, cos_t]])
@@ -1344,6 +1347,16 @@ class SeestarQueuedStacker:
         self.reference_wcs_object = ref_wcs
         self.reference_shape = ref_shape
         self.reference_header_for_wcs = ref_wcs.to_header()
+        try:
+            self.reference_wcs_object.pixel_shape = (
+                self.reference_shape[1],
+                self.reference_shape[0],
+            )
+            self.reference_wcs_object._naxis1 = self.reference_shape[1]
+            self.reference_wcs_object._naxis2 = self.reference_shape[0]
+        except Exception:
+            pass
+
         self.reproject_between_batches = True
 
         crval = ", ".join(f"{x:.5f}" for x in ref_wcs.wcs.crval)
@@ -3419,10 +3432,13 @@ class SeestarQueuedStacker:
                     self.processing_error = "WCS de référence manquant pour reprojection."
                     self.stop_processing = True
                     return
-                target_shape_hw = (
-                    reference_wcs_for_reprojection.pixel_shape[1],
-                    reference_wcs_for_reprojection.pixel_shape[0],
-                )
+                if self.reference_shape is not None:
+                    target_shape_hw = self.reference_shape
+                else:
+                    target_shape_hw = (
+                        reference_wcs_for_reprojection.pixel_shape[1],
+                        reference_wcs_for_reprojection.pixel_shape[0],
+                    )
                 self.master_sum = np.zeros((*target_shape_hw, 3), dtype=np.float32)
                 self.master_coverage = np.zeros(target_shape_hw, dtype=np.float32)
 


### PR DESCRIPTION
## Summary
- sync pixel_shape with dynamic global WCS
- initialize reprojection arrays from `reference_shape` when available
- fix CRPIX so the mosaic canvas is correctly centered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d6cb37d24832f9a77aea2aabd2693