### PR TITLE
Enable multiprocessing for WCS reprojection

### DIFF
--- a/seestar/core/__init__.py
+++ b/seestar/core/__init__.py
@@ -18,6 +18,7 @@ from .weights import (
     _calculate_image_weights_noise_fwhm,
 )
 from .incremental_reprojection import reproject_and_combine
+from .reprojection import resolve_all_wcs
 from .simple_stacker import create_master_tile as create_master_tile_simple
 
 # Liste initiale des éléments à exporter
@@ -35,7 +36,8 @@ __all__ = [
     '_calculate_image_weights_noise_variance',
     '_calculate_image_weights_noise_fwhm',
     'create_master_tile_simple',
-    'reproject_and_combine'
+    'reproject_and_combine',
+    'resolve_all_wcs'
 ]
 
 # Tentative d'importation du nouvel aligneur local


### PR DESCRIPTION
## Summary
- add parallel `resolve_all_wcs` helper in `seestar.core.reprojection`
- expose `resolve_all_wcs` from `seestar.core`

## Testing
- `pytest -q` *(fails: test_resolve_after_crop, test_solver_header_values_no_wcs, test_use_sidecar_wcs, test_output_scale_warning_and_adjust, test_grid_uses_resolved_wcs)*

------
https://chatgpt.com/codex/tasks/task_e_684dac3562b4832f9fb476131e39cb2e