### PR TITLE
Implement fixed grid reprojection

### DIFF
--- a/seestar/core/__init__.py
+++ b/seestar/core/__init__.py
@@ -19,6 +19,7 @@ from .weights import (
 )
 from .incremental_reprojection import reproject_and_combine
 from .reprojection import resolve_all_wcs
+from .reprojection_utils import collect_headers, compute_final_output_grid
 from .simple_stacker import create_master_tile as create_master_tile_simple
 
 # Liste initiale des éléments à exporter
@@ -37,7 +38,9 @@ __all__ = [
     '_calculate_image_weights_noise_fwhm',
     'create_master_tile_simple',
     'reproject_and_combine',
-    'resolve_all_wcs'
+    'resolve_all_wcs',
+    'collect_headers',
+    'compute_final_output_grid'
 ]
 
 # Tentative d'importation du nouvel aligneur local

--- a/seestar/core/reprojection_utils.py
+++ b/seestar/core/reprojection_utils.py
@@ -1,0 +1,91 @@
+"""Utility helpers for pre-scanning FITS headers and computing a fixed output WCS."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+import math
+
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_scales
+
+
+HeaderInfo = Tuple[Tuple[int, int], WCS]
+
+
+def collect_headers(filepaths: Iterable[str]) -> List[HeaderInfo]:
+    """Return a list of ``(shape_hw, WCS)`` tuples for each FITS file path."""
+    infos: List[HeaderInfo] = []
+    for path in filepaths:
+        try:
+            hdr = fits.getheader(path, memmap=False)
+            wcs = WCS(hdr)
+            if not wcs.is_celestial:
+                continue
+            naxis1 = int(hdr.get("NAXIS1"))
+            naxis2 = int(hdr.get("NAXIS2"))
+            shape_hw = (naxis2, naxis1)
+            infos.append((shape_hw, wcs))
+        except Exception:
+            continue
+    return infos
+
+
+def compute_final_output_grid(header_infos: Iterable[HeaderInfo], scale: float = 1.0) -> Tuple[WCS, Tuple[int, int]]:
+    """Compute a fixed output WCS and shape covering all inputs."""
+    header_list = list(header_infos)
+    if not header_list:
+        raise ValueError("No header infos provided")
+
+    ref_wcs = header_list[0][1]
+
+    xmin = math.inf
+    ymin = math.inf
+    xmax = -math.inf
+    ymax = -math.inf
+    pixel_scales = []
+
+    for shape_hw, wcs in header_list:
+        h, w = shape_hw
+        corners = np.array([[0, 0], [w - 1, 0], [w - 1, h - 1], [0, h - 1]], dtype=float)
+        sky = wcs.pixel_to_world(corners[:, 0], corners[:, 1])
+        x, y = ref_wcs.world_to_pixel(sky)
+        xmin = min(xmin, float(np.min(x)))
+        xmax = max(xmax, float(np.max(x)))
+        ymin = min(ymin, float(np.min(y)))
+        ymax = max(ymax, float(np.max(y)))
+        try:
+            pixel_scales.append(np.mean(np.abs(proj_plane_pixel_scales(wcs))))
+        except Exception:
+            pass
+
+    if not pixel_scales:
+        pixel_scales.append(np.mean(np.abs(proj_plane_pixel_scales(ref_wcs))))
+
+    min_scale_deg = float(np.min(pixel_scales))
+    output_scale_deg = min_scale_deg / max(scale, 1.0)
+
+    xmin_f = math.floor(xmin) - 1
+    ymin_f = math.floor(ymin) - 1
+    xmax_f = math.ceil(xmax) + 1
+    ymax_f = math.ceil(ymax) + 1
+
+    out_w = int(xmax_f - xmin_f)
+    out_h = int(ymax_f - ymin_f)
+
+    out_wcs = WCS(naxis=2)
+    out_wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    out_wcs.wcs.crval = list(ref_wcs.wcs.crval)
+    out_wcs.wcs.crpix = [-xmin_f + 0.5, -ymin_f + 0.5]
+    out_wcs.wcs.cd = np.array([[-output_scale_deg, 0.0], [0.0, output_scale_deg]])
+    out_wcs.pixel_shape = (out_w, out_h)
+    try:
+        out_wcs._naxis1 = out_w
+        out_wcs._naxis2 = out_h
+    except Exception:
+        pass
+
+    return out_wcs, (out_h, out_w)
+

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -799,35 +799,47 @@ class SeestarQueuedStacker:
             wht_shape_memmap = self.memmap_shape[:2]
             logger.debug(f"  -> Shape Memmap SUM={self.memmap_shape}, WHT={wht_shape_memmap}")
 
-            if self.reproject_between_batches:
-                logger.debug("  -> reproject_between_batches=True: Memmaps SUM/WHT non créés (mode incrémental).")
+            logger.debug(
+                "  -> Tentative création/ouverture fichiers memmap SUM/WHT (mode 'w+')..."
+            )
+            try:
+                self.cumulative_sum_memmap = np.lib.format.open_memmap(
+                    self.sum_memmap_path,
+                    mode='w+',
+                    dtype=self.memmap_dtype_sum,
+                    shape=self.memmap_shape,
+                )
+                self.cumulative_sum_memmap[:] = 0.0
+                logger.debug(
+                    f"  -> Memmap SUM ({self.memmap_shape}) créé/ouvert et initialisé à zéro."
+                )
+
+                self.cumulative_wht_memmap = np.lib.format.open_memmap(
+                    self.wht_memmap_path,
+                    mode='w+',
+                    dtype=self.memmap_dtype_wht,
+                    shape=wht_shape_memmap,
+                )
+                self.cumulative_wht_memmap[:] = 0
+                logger.debug(
+                    f"  -> Memmap WHT ({wht_shape_memmap}) créé/ouvert et initialisé à zéro."
+                )
+
+                self.incremental_drizzle_objects = []
+
+            except (IOError, OSError, ValueError, TypeError) as e_memmap:
+                self.update_progress(
+                    f"❌ Erreur création/initialisation fichier memmap: {e_memmap}"
+                )
+                logger.debug(
+                    f"ERREUR QM [initialize V_DrizIncr_StrategyA_Init_MemmapDirFix]: Échec memmap : {e_memmap}"
+                )
+                traceback.print_exc(limit=2)
                 self.cumulative_sum_memmap = None
                 self.cumulative_wht_memmap = None
-                self.master_sum = None
-                self.master_coverage = None
-            else:
-                logger.debug(f"  -> Tentative création/ouverture fichiers memmap SUM/WHT (mode 'w+')...")
-                try:
-                    self.cumulative_sum_memmap = np.lib.format.open_memmap(
-                        self.sum_memmap_path, mode='w+', dtype=self.memmap_dtype_sum, shape=self.memmap_shape
-                    )
-                    self.cumulative_sum_memmap[:] = 0.0
-                    logger.debug(f"  -> Memmap SUM ({self.memmap_shape}) créé/ouvert et initialisé à zéro.")
-
-                    self.cumulative_wht_memmap = np.lib.format.open_memmap(
-                        self.wht_memmap_path, mode='w+', dtype=self.memmap_dtype_wht, shape=wht_shape_memmap
-                    )
-                    self.cumulative_wht_memmap[:] = 0
-                    logger.debug(f"  -> Memmap WHT ({wht_shape_memmap}) créé/ouvert et initialisé à zéro.")
-
-                    self.incremental_drizzle_objects = []
-
-                except (IOError, OSError, ValueError, TypeError) as e_memmap:
-                    self.update_progress(f"❌ Erreur création/initialisation fichier memmap: {e_memmap}")
-                    logger.debug(f"ERREUR QM [initialize V_DrizIncr_StrategyA_Init_MemmapDirFix]: Échec memmap : {e_memmap}"); traceback.print_exc(limit=2)
-                    self.cumulative_sum_memmap = None; self.cumulative_wht_memmap = None
-                    self.sum_memmap_path = None; self.wht_memmap_path = None
-                    return False
+                self.sum_memmap_path = None
+                self.wht_memmap_path = None
+                return False
         
         # --- Réinitialisations Communes ---
         self.warned_unaligned_source_folders.clear()
@@ -1973,7 +1985,7 @@ class SeestarQueuedStacker:
             self._recalculate_total_batches()
 
             ok_grid = True
-            if self.reproject_between_batches:
+            if self.reproject_between_batches and self.fixed_output_wcs is None:
                 ok_grid = self._prepare_global_reprojection_grid()
                 if not ok_grid:
                     self.update_progress("❌ Failed to initialise global WCS grid", "ERROR")
@@ -6227,7 +6239,38 @@ class SeestarQueuedStacker:
             self.batch_size = max(3, int(requested_batch_size)) 
         self.update_progress(f"ⓘ Taille de lot effective pour le traitement : {self.batch_size}")
         logger.debug("DEBUG QM (start_processing): Fin Étape 1 - Configuration des paramètres de session.")
-        
+
+        # --- NEW STEP: Pre-scan headers to compute a fixed output grid ---
+        if self.reproject_between_batches:
+            all_paths = []
+            if self.current_folder and os.path.isdir(self.current_folder):
+                for fn in sorted(os.listdir(self.current_folder)):
+                    if fn.lower().endswith((".fit", ".fits")):
+                        all_paths.append(os.path.join(self.current_folder, fn))
+            if initial_additional_folders:
+                for f in initial_additional_folders:
+                    abs_f = os.path.abspath(str(f))
+                    if os.path.isdir(abs_f):
+                        for fn in sorted(os.listdir(abs_f)):
+                            if fn.lower().endswith((".fit", ".fits")):
+                                all_paths.append(os.path.join(abs_f, fn))
+            from ..core.reprojection_utils import collect_headers, compute_final_output_grid
+            header_infos = collect_headers(all_paths)
+            if header_infos:
+                try:
+                    self.fixed_output_wcs, self.fixed_output_shape = compute_final_output_grid(
+                        header_infos, scale=self.drizzle_scale
+                    )
+                    self.reference_wcs_object = self.fixed_output_wcs
+                    self.reference_shape = self.fixed_output_shape
+                    self.update_progress(
+                        f"🗺️ Grille fixe calculée {self.fixed_output_shape} px.",
+                        None,
+                    )
+                except Exception as e_grid:
+                    self.update_progress(f"⚠️ Erreur calcul grille fixe: {e_grid}", "WARN")
+            self.all_input_filepaths = all_paths
+
 
 
         # --- ÉTAPE 2 : PRÉPARATION DE L'IMAGE DE RÉFÉRENCE (shape ET WCS global si nécessaire) ---


### PR DESCRIPTION
## Summary
- add `collect_headers` and `compute_final_output_grid` helpers
- pre-scan FITS headers in `start_processing` to build a fixed output frame
- skip heavy grid solve in worker when a fixed grid already exists
- always create SUM/WHT memmaps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df8e14824832f80af4867cc89b91d