### PR TITLE
Enable final edge crop

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -233,14 +233,6 @@ except ImportError as e:
     apply_scnr = None  # Fonction factice
     logger.warning("Échec import apply_scnr: %s", e)
 
-_CROP_AVAILABLE = False  # Rognage Final
-try:
-    from ..enhancement.stack_enhancement import apply_edge_crop
-    _CROP_AVAILABLE = True
-    logger.debug("Import apply_edge_crop OK.")
-except ImportError as e:
-    apply_edge_crop = None  # Fonction factice
-    logger.warning("Échec import apply_edge_crop: %s", e)
 
 # --- Imports INTERNES à déplacer en IMPORTS TARDIFS ---
 # Ces modules seront importés seulement quand les méthodes spécifiques sont appelées
@@ -5667,6 +5659,12 @@ class SeestarQueuedStacker:
         logger.debug(
             f"  DEBUG QM [_save_final_stack]: self.raw_adu_data_for_ui_histogram STOCKE (ADU). Range: [{np.min(self.raw_adu_data_for_ui_histogram):.3f}, {np.max(self.raw_adu_data_for_ui_histogram):.3f}]"
         )
+        if getattr(self, "final_edge_crop_percent_decimal", 0.0) > 0:
+            crop_val = self.final_edge_crop_percent_decimal
+            self.raw_adu_data_for_ui_histogram = apply_edge_crop(
+                self.raw_adu_data_for_ui_histogram,
+                crop_val,
+            )
 
         # --- Normalisation par percentiles pour obtenir final_image_normalized_for_cosmetics (0-1) ---
         if preserve_linear_output_setting:
@@ -5731,6 +5729,11 @@ class SeestarQueuedStacker:
 
         # data_after_postproc est la version 0-1 qui subira les post-traitements cosmétiques.
         data_after_postproc = final_image_normalized_for_cosmetics.copy()
+        if getattr(self, "final_edge_crop_percent_decimal", 0.0) > 0:
+            data_after_postproc = apply_edge_crop(
+                data_after_postproc,
+                self.final_edge_crop_percent_decimal,
+            )
 
         self.update_progress(f"  DEBUG QM [SaveFinalStack] data_after_postproc (AVANT post-traitements) - Range: [{np.nanmin(data_after_postproc):.4f}, {np.nanmax(data_after_postproc):.4f}]")
         logger.debug(f"  DEBUG QM [SaveFinalStack] data_after_postproc (AVANT post-traitements) - Range: [{np.nanmin(data_after_postproc):.4f}, {np.nanmax(data_after_postproc):.4f}]")

--- a/tests/test_save_final_stack.py
+++ b/tests/test_save_final_stack.py
@@ -365,3 +365,23 @@ def test_save_final_stack_classic_reproject_crop(tmp_path):
     assert np.array_equal(saved.astype(np.float32), data[1:3, 1:3])
     assert header["CRPIX1"] == 1.0
     assert header["CRPIX2"] == 1.0
+
+
+def test_save_final_stack_final_edge_crop(tmp_path):
+    obj = _make_obj(tmp_path, True)
+    obj.reproject_between_batches = True
+    obj.preserve_linear_output = True
+    obj.final_edge_crop_percent_decimal = 0.25
+
+    data = np.arange(16, dtype=np.float32).reshape(4, 4)
+    wht = np.ones_like(data, dtype=np.float32)
+
+    qm.SeestarQueuedStacker._save_final_stack(
+        obj,
+        output_filename_suffix="_edge_crop",
+        drizzle_final_sci_data=data,
+        drizzle_final_wht_data=wht,
+    )
+
+    saved = fits.getdata(obj.final_stacked_path)
+    assert saved.shape == (2, 2)


### PR DESCRIPTION
## Summary
- remove unused import fallback for apply_edge_crop
- crop the final stack when `final_edge_crop_percent_decimal` is set
- test that final edge cropping shrinks FITS dimensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1505e2a4832fb607a487f221334c