### PR TITLE
Ensure solver disabled when third-party use is off

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -3184,23 +3184,25 @@ class SeestarStackerGUI:
             # started from another directory by using the project root as cwd
             project_root = Path(__file__).resolve().parents[2]
             env = os.environ.copy()
-            if getattr(self.settings, "astap_path", ""):
-                env["ZEMOSAIC_ASTAP_PATH"] = str(self.settings.astap_path)
-            if getattr(self.settings, "astap_data_dir", ""):
-                env["ZEMOSAIC_ASTAP_DATA_DIR"] = str(self.settings.astap_data_dir)
-            if getattr(self.settings, "local_ansvr_path", ""):
-                env["ZEMOSAIC_LOCAL_ANSVR_PATH"] = str(self.settings.local_ansvr_path)
-            if getattr(self.settings, "astrometry_api_key", ""):
-                env["ZEMOSAIC_ASTROMETRY_API_KEY"] = str(self.settings.astrometry_api_key)
-            if getattr(self.settings, "astrometry_solve_field_dir", ""):
-                env["ZEMOSAIC_ASTROMETRY_DIR"] = str(self.settings.astrometry_solve_field_dir)
-            if getattr(self.settings, "local_solver_preference", ""):
-                env["ZEMOSAIC_LOCAL_SOLVER_PREFERENCE"] = str(self.settings.local_solver_preference)
-            try:
-                radius_val = float(getattr(self.settings, "astap_search_radius", 0))
-                env["ZEMOSAIC_ASTAP_SEARCH_RADIUS"] = str(radius_val)
-            except Exception:
-                pass
+            if self.settings.use_third_party_solver:
+                if getattr(self.settings, "astap_path", ""):
+                    env["ZEMOSAIC_ASTAP_PATH"] = str(self.settings.astap_path)
+                if getattr(self.settings, "astap_data_dir", ""):
+                    env["ZEMOSAIC_ASTAP_DATA_DIR"] = str(self.settings.astap_data_dir)
+                if getattr(self.settings, "local_ansvr_path", ""):
+                    env["ZEMOSAIC_LOCAL_ANSVR_PATH"] = str(self.settings.local_ansvr_path)
+                if getattr(self.settings, "astrometry_api_key", ""):
+                    env["ZEMOSAIC_ASTROMETRY_API_KEY"] = str(self.settings.astrometry_api_key)
+                if getattr(self.settings, "astrometry_solve_field_dir", ""):
+                    env["ZEMOSAIC_ASTROMETRY_DIR"] = str(self.settings.astrometry_solve_field_dir)
+                if getattr(self.settings, "local_solver_preference", ""):
+                    env["ZEMOSAIC_LOCAL_SOLVER_PREFERENCE"] = str(self.settings.local_solver_preference)
+            if self.settings.use_third_party_solver:
+                try:
+                    radius_val = float(getattr(self.settings, "astap_search_radius", 0))
+                    env["ZEMOSAIC_ASTAP_SEARCH_RADIUS"] = str(radius_val)
+                except Exception:
+                    pass
 
             # Directly execute the run_zemosaic.py script located in the
             # ``zemosaic`` directory of the project. Using the explicit file
@@ -4174,6 +4176,12 @@ class SeestarStackerGUI:
         if not self.settings.use_third_party_solver:
             self.settings.local_solver_preference = "none"
             self.settings.reproject_between_batches = False
+            # Clear solver-specific settings to ensure no external solver is used
+            self.settings.astrometry_api_key = ""
+            self.settings.local_ansvr_path = ""
+            self.settings.astap_path = ""
+            self.settings.astap_data_dir = ""
+            self.settings.astrometry_solve_field_dir = ""
 
         # --- 6. Appel à queued_stacker.start_processing ---
         print("DEBUG (GUI start_processing): Phase 6 - Appel à queued_stacker.start_processing...")

--- a/tests/test_queue_manager_reproject.py
+++ b/tests/test_queue_manager_reproject.py
@@ -223,6 +223,63 @@ def test_process_file_skips_solver_when_disabled(tmp_path, monkeypatch):
     assert calls["n"] == 0
 
 
+def test_process_file_no_solver_with_paths_and_api_key(tmp_path, monkeypatch):
+    """Solver should not run when disabled even if paths/api key are set."""
+    sys.path.insert(0, str(ROOT))
+    import importlib
+    import types
+
+    if "seestar.gui" not in sys.modules:
+        seestar_pkg = types.ModuleType("seestar")
+        seestar_pkg.__path__ = [str(ROOT / "seestar")]
+        gui_pkg = types.ModuleType("seestar.gui")
+        gui_pkg.__path__ = []
+        settings_mod = types.ModuleType("seestar.gui.settings")
+
+        class DummySettingsManager:
+            pass
+
+        settings_mod.SettingsManager = DummySettingsManager
+        hist_mod = types.ModuleType("seestar.gui.histogram_widget")
+        hist_mod.HistogramWidget = object
+        gui_pkg.settings = settings_mod
+        gui_pkg.histogram_widget = hist_mod
+        seestar_pkg.gui = gui_pkg
+        sys.modules["seestar"] = seestar_pkg
+        sys.modules["seestar.gui"] = gui_pkg
+        sys.modules["seestar.gui.settings"] = settings_mod
+        sys.modules["seestar.gui.histogram_widget"] = hist_mod
+
+    qm = importlib.import_module("seestar.queuep.queue_manager")
+
+    calls = {"n": 0}
+
+    class DummySolver:
+        def solve(self, *a, **k):
+            calls["n"] += 1
+            return make_wcs(shape=(4, 4))
+
+    obj = qm.SeestarQueuedStacker()
+    obj.update_progress = lambda *a, **k: None
+    obj.reproject_between_batches = False
+    obj.reference_wcs_object = make_wcs(shape=(4, 4))
+    obj.reference_pixel_scale_arcsec = 1.0
+    obj.astrometry_solver = DummySolver()
+    obj.local_solver_preference = "ansvr"
+    obj.astap_path = "/tmp/astap"
+    obj.astap_data_dir = "/tmp/data"
+    obj.local_ansvr_path = "/tmp/ansvr"
+    obj.api_key = "SECRET"
+
+    data = np.random.random((8, 8, 3)).astype(np.float32)
+    path = tmp_path / "test.fits"
+    fits.writeto(path, data, overwrite=True)
+
+    obj._process_file(str(path), data, solve_astrometry_for_this_file=False)
+
+    assert calls["n"] == 0
+
+
 def test_stack_batch_uses_master_tile_when_all_have_wcs(tmp_path, monkeypatch):
     sys.path.insert(0, str(ROOT))
     import importlib


### PR DESCRIPTION
## Summary
- clear solver credentials and paths when third-party solvers disabled
- avoid passing solver environment variables to ZeMosaic when disabled
- add regression test for disabled solver with configured paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb622dcb4832fb310058e5d569323