### PR TITLE
Use reproject_and_coadd for batch reprojection

### DIFF
--- a/seestar/core/incremental_reprojection.py
+++ b/seestar/core/incremental_reprojection.py
@@ -75,3 +75,104 @@ def reproject_and_combine(
     master_cov = np.nan_to_num(master_cov, nan=0.0, posinf=0.0, neginf=0.0)
 
     return master_sum.astype(np.float32), master_cov.astype(np.float32)
+
+
+def reproject_and_coadd_batch(
+    image_array_list,
+    header_list,
+    target_wcs,
+    target_shape_hw,
+    combine_function="mean",
+):
+    """Reproject a batch of images and combine them with ``reproject_and_coadd``.
+
+    Parameters
+    ----------
+    image_array_list : list of np.ndarray
+        Images to reproject. Each array can be ``H x W`` or ``H x W x C``.
+    header_list : list of ``astropy.io.fits.Header``
+        FITS headers containing valid WCS for the corresponding images.
+    target_wcs : astropy.wcs.WCS
+        Output WCS grid to project onto.
+    target_shape_hw : tuple
+        Shape ``(H, W)`` of the output grid.
+    combine_function : str, optional
+        Combination method passed to ``reproject_and_coadd``.
+
+    Returns
+    -------
+    tuple
+        (combined_image, coverage_map) both ``np.ndarray`` in the target frame
+        or ``(None, None)`` if reprojection failed.
+    """
+
+    from seestar.enhancement.reproject_utils import (
+        reproject_and_coadd,
+        reproject_interp,
+    )
+
+    if not image_array_list or not header_list:
+        return None, None
+
+    pairs = []
+    weights = []
+    for img, hdr in zip(image_array_list, header_list):
+        if img is None or hdr is None:
+            continue
+        try:
+            wcs = WCS(hdr, naxis=2)
+            if not wcs.is_celestial:
+                continue
+            if wcs.pixel_shape is None:
+                h, w = img.shape[:2]
+                wcs.pixel_shape = (w, h)
+        except Exception:
+            continue
+        pairs.append((img, wcs))
+        weights.append(np.ones(img.shape[:2], dtype=np.float32))
+
+    if not pairs:
+        return None, None
+
+    first_img = pairs[0][0]
+    if first_img.ndim == 2:
+        data_list = pairs
+        cov_list = weights
+        result, footprint = reproject_and_coadd(
+            data_list,
+            output_projection=target_wcs,
+            shape_out=target_shape_hw,
+            input_weights=cov_list,
+            reproject_function=reproject_interp,
+            combine_function=combine_function,
+            match_background=True,
+        )
+        return result.astype(np.float32), footprint.astype(np.float32)
+
+    # Colour images
+    n_channels = first_img.shape[2]
+    channel_arrays = [[] for _ in range(n_channels)]
+    channel_weights = [[] for _ in range(n_channels)]
+    for img, wcs in pairs:
+        for c in range(n_channels):
+            channel_arrays[c].append((img[:, :, c], wcs))
+            channel_weights[c].append(np.ones(img.shape[:2], dtype=np.float32))
+
+    final_channels = []
+    final_cov = None
+    for c in range(n_channels):
+        res, cov = reproject_and_coadd(
+            channel_arrays[c],
+            output_projection=target_wcs,
+            shape_out=target_shape_hw,
+            input_weights=channel_weights[c],
+            reproject_function=reproject_interp,
+            combine_function=combine_function,
+            match_background=True,
+        )
+        final_channels.append(res.astype(np.float32))
+        if final_cov is None:
+            final_cov = cov.astype(np.float32)
+
+    combined = np.stack(final_channels, axis=-1)
+    return combined, final_cov

--- a/tests/test_incremental_reprojection.py
+++ b/tests/test_incremental_reprojection.py
@@ -1,0 +1,77 @@
+import importlib
+import sys
+from pathlib import Path
+
+import numpy as np
+from astropy.wcs import WCS
+from astropy.io import fits
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+if "seestar.gui" not in sys.modules:
+    import types
+
+    seestar_pkg = types.ModuleType("seestar")
+    seestar_pkg.__path__ = [str(ROOT / "seestar")]
+    gui_pkg = types.ModuleType("seestar.gui")
+    gui_pkg.__path__ = []
+    settings_mod = types.ModuleType("seestar.gui.settings")
+
+    class DummySettingsManager:
+        pass
+
+    settings_mod.SettingsManager = DummySettingsManager
+    hist_mod = types.ModuleType("seestar.gui.histogram_widget")
+    hist_mod.HistogramWidget = object
+    gui_pkg.settings = settings_mod
+    gui_pkg.histogram_widget = hist_mod
+    seestar_pkg.gui = gui_pkg
+    sys.modules["seestar"] = seestar_pkg
+    sys.modules["seestar.gui"] = gui_pkg
+    sys.modules["seestar.gui.settings"] = settings_mod
+sys.modules["seestar.gui.histogram_widget"] = hist_mod
+
+spec = importlib.util.spec_from_file_location(
+    "seestar.enhancement.reproject_utils",
+    ROOT / "seestar" / "enhancement" / "reproject_utils.py",
+)
+reproj_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(reproj_module)
+sys.modules["seestar.enhancement.reproject_utils"] = reproj_module
+if "seestar.core.incremental_reprojection" in sys.modules:
+    import importlib as _importlib
+    _importlib.reload(sys.modules["seestar.core.incremental_reprojection"])
+
+mod = importlib.import_module("seestar.core.incremental_reprojection")
+reproject_and_coadd_batch = mod.reproject_and_coadd_batch
+
+
+def make_wcs(shape=(4, 4)):
+    w = WCS(naxis=2)
+    w.wcs.crpix = [shape[1] / 2, shape[0] / 2]
+    w.wcs.cdelt = np.array([-0.01, 0.01])
+    w.wcs.crval = [0, 0]
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    w.pixel_shape = (shape[1], shape[0])
+    return w
+
+
+def test_reproject_and_coadd_batch_rgb():
+    # reload real reproject_utils in case another test replaced it
+    spec = importlib.util.spec_from_file_location(
+        "seestar.enhancement.reproject_utils",
+        ROOT / "seestar" / "enhancement" / "reproject_utils.py",
+    )
+    reproj_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(reproj_module)
+    sys.modules["seestar.enhancement.reproject_utils"] = reproj_module
+
+    wcs_in = make_wcs()
+    hdr = wcs_in.to_header()
+    img = np.random.random((4, 4, 3)).astype(np.float32)
+    out, cov = reproject_and_coadd_batch([img], [hdr], wcs_in, (4, 4))
+    assert out.shape == (4, 4, 3)
+    assert cov.shape == (4, 4)
+
+


### PR DESCRIPTION
## Summary
- add `reproject_and_coadd_batch` helper to combine whole batches
- call new function from `SeestarQueuedStacker` when reprojecting between batches
- save intermediate reprojected batches and accumulate via `_combine_batch_result`
- finalize classic reprojection from SUM/W memmaps
- test incremental reprojection helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0a6c6e20832f88672cc31351db4f