### PR TITLE
Fix incremental reprojection initialization

### DIFF
--- a/seestar/core/incremental_reprojection.py
+++ b/seestar/core/incremental_reprojection.py
@@ -6,7 +6,12 @@ from astropy.wcs import WCS
 from .reprojection import reproject_to_reference_wcs
 
 
-def initialize_master(batch_img: np.ndarray, batch_cov: np.ndarray, ref_wcs: WCS):
+def initialize_master(
+    batch_img: np.ndarray,
+    batch_cov: np.ndarray,
+    batch_wcs: WCS,
+    ref_wcs: WCS,
+):
     """Return initial weighted sum and coverage map.
 
     Parameters
@@ -15,21 +20,40 @@ def initialize_master(batch_img: np.ndarray, batch_cov: np.ndarray, ref_wcs: WCS
         Stacked image from the first batch.
     batch_cov : np.ndarray
         Coverage/weight map for the batch.
+    batch_wcs : astropy.wcs.WCS
+        WCS of the first batch.
     ref_wcs : astropy.wcs.WCS
         Reference WCS used for later reprojection.
+
+    The first batch is reprojected so that all subsequent batches
+    accumulate on the same grid.
     """
     if batch_img is None or batch_cov is None:
         raise ValueError("batch_img and batch_cov are required")
     batch_img_f = batch_img.astype(np.float32, copy=True)
     batch_cov_f = batch_cov.astype(np.float32, copy=True)
 
-    if batch_img_f.ndim == 3:
-        master_sum = batch_img_f * batch_cov_f[..., None]
-    else:
-        master_sum = batch_img_f * batch_cov_f
+    target_shape = (
+        (ref_wcs.pixel_shape[1], ref_wcs.pixel_shape[0])
+        if ref_wcs.pixel_shape is not None
+        else batch_img_f.shape[:2]
+    )
 
-    master_cov = batch_cov_f
-    return master_sum, master_cov
+    reproj_img = reproject_to_reference_wcs(
+        batch_img_f, batch_wcs, ref_wcs, target_shape
+    )
+    reproj_cov = reproject_to_reference_wcs(
+        batch_cov_f, batch_wcs, ref_wcs, target_shape
+    )
+
+    if reproj_img.ndim == 3:
+        master_sum = reproj_img * reproj_cov[..., None]
+    else:
+        master_sum = reproj_img * reproj_cov
+
+    master_cov = reproj_cov
+
+    return master_sum.astype(np.float32), master_cov.astype(np.float32)
 
 
 def reproject_and_combine(
@@ -45,10 +69,11 @@ def reproject_and_combine(
     if batch_wcs is None or ref_wcs is None:
         return master_sum, master_cov
 
-    # Use the existing master array dimensions to avoid orientation issues
-    target_shape = master_sum.shape[:2]
-    if ref_wcs.pixel_shape is not None:
-        target_shape = (ref_wcs.pixel_shape[1], ref_wcs.pixel_shape[0])
+    target_shape = (
+        (ref_wcs.pixel_shape[1], ref_wcs.pixel_shape[0])
+        if ref_wcs.pixel_shape is not None
+        else master_sum.shape[:2]
+    )
 
     reproj_img = reproject_to_reference_wcs(batch_img, batch_wcs, ref_wcs, target_shape)
     reproj_cov = reproject_to_reference_wcs(batch_cov, batch_wcs, ref_wcs, target_shape)
@@ -74,6 +99,7 @@ def reproject_and_combine(
     master_sum = np.nan_to_num(master_sum, nan=0.0, posinf=0.0, neginf=0.0)
     master_cov = np.nan_to_num(master_cov, nan=0.0, posinf=0.0, neginf=0.0)
 
+    print(np.nanmin(master_cov), np.nanmax(master_cov))
     return master_sum.astype(np.float32), master_cov.astype(np.float32)
 
 


### PR DESCRIPTION
## Summary
- reproject the first batch in `initialize_master`
- always use `ref_wcs.pixel_shape` for reprojection geometry
- print coverage range after combining for quick sanity check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc7d0a748832fb5c961310a762a24