### PR TITLE
Improve prescan order

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -3061,13 +3061,18 @@ class SeestarStackerGUI:
 
         widgets_to_set = []
         if state == tk.NORMAL:
-            print("DEBUG (GUI _set_parameter_widgets_state): Activation de tous les widgets...") 
+            print("DEBUG (GUI _set_parameter_widgets_state): Activation de tous les widgets...")
             # Activer TOUS les widgets (traitement + preview) quand le traitement finit
             widgets_to_set = processing_widgets + preview_widgets
             # S'assurer que les options de pondération ET DRIZZLE sont dans le bon état initial
             self._update_weighting_options_state()
             self._update_drizzle_options_state() # <-- Appel ajouté ici
             # ... (reste de la logique pour state == tk.NORMAL) ...
+            if hasattr(self, 'add_files_button'):
+                try:
+                    self.add_files_button.config(state=tk.NORMAL)
+                except tk.TclError:
+                    pass
 
         else: # tk.DISABLED (Pendant le traitement)
             # Désactiver les paramètres de traitement (y compris Drizzle)
@@ -3075,8 +3080,16 @@ class SeestarStackerGUI:
             # Les widgets de preview restent actifs
             for widget in preview_widgets:
                 # ... (logique existante) ...
-            # Le bouton Ajouter Dossier reste NORMAL
-                if hasattr(self, 'add_files_button'): self.add_files_button.config(state=tk.NORMAL)
+                pass
+            # Le bouton Ajouter Dossier est désactivé si la reprojection est active
+            if hasattr(self, 'add_files_button'):
+                btn_state = tk.NORMAL
+                if getattr(self.settings, 'reproject_between_batches', False):
+                    btn_state = tk.DISABLED
+                try:
+                    self.add_files_button.config(state=btn_state)
+                except tk.TclError:
+                    pass
 
         # Appliquer l'état aux widgets sélectionnés
         for widget in widgets_to_set:

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -745,19 +745,27 @@ class SeestarQueuedStacker:
         logger.debug(f"    -> not self.is_mosaic_run ÉTAIT: {not self.is_mosaic_run} (self.is_mosaic_run était {self.is_mosaic_run})")
 
         if is_true_incremental_drizzle_mode:
-            logger.debug("DEBUG QM [initialize V_DrizIncr_StrategyA_Init_MemmapDirFix]: Mode Drizzle Incrémental VRAI détecté.")
+            logger.debug(
+                "DEBUG QM [initialize V_DrizIncr_StrategyA_Init_MemmapDirFix]: Mode Drizzle Incrémental VRAI détecté."
+            )
             if self.reference_wcs_object is None:
-                self.update_progress("❌ Erreur: WCS de référence manquant pour initialiser la grille Drizzle Incrémental.", "ERROR")
+                self.update_progress(
+                    "❌ Erreur: WCS de référence manquant pour initialiser la grille Drizzle Incrémental.",
+                    "ERROR",
+                )
                 return False
             try:
                 ref_shape_hw_for_grid = reference_image_shape_hwc_input[:2]
-                self.drizzle_output_wcs, self.drizzle_output_shape_hw = self._create_drizzle_output_wcs(
-                    self.reference_wcs_object, ref_shape_hw_for_grid, self.drizzle_scale
-                )
                 if self.drizzle_output_wcs is None or self.drizzle_output_shape_hw is None:
-                    raise RuntimeError("Échec _create_drizzle_output_wcs pour Drizzle Incrémental.")
+                    self.drizzle_output_wcs, self.drizzle_output_shape_hw = self._create_drizzle_output_wcs(
+                        self.reference_wcs_object, ref_shape_hw_for_grid, self.drizzle_scale
+                    )
+                    if self.drizzle_output_wcs is None or self.drizzle_output_shape_hw is None:
+                        raise RuntimeError("Échec _create_drizzle_output_wcs pour Drizzle Incrémental.")
                 current_output_shape_hw_for_accum_or_driz = self.drizzle_output_shape_hw
-                logger.debug(f"  -> Grille Drizzle Incrémental: Shape={current_output_shape_hw_for_accum_or_driz}, WCS CRVAL={self.drizzle_output_wcs.wcs.crval if self.drizzle_output_wcs.wcs else 'N/A'}")
+                logger.debug(
+                    f"  -> Grille Drizzle Incrémental: Shape={current_output_shape_hw_for_accum_or_driz}, WCS CRVAL={self.drizzle_output_wcs.wcs.crval if self.drizzle_output_wcs.wcs else 'N/A'}"
+                )
             except Exception as e_grid:
                 self.update_progress(f"❌ Erreur création grille Drizzle Incrémental: {e_grid}", "ERROR")
                 return False
@@ -1605,24 +1613,41 @@ class SeestarQueuedStacker:
         }
 
         total = len(self.all_input_filepaths)
-        for idx, fpath in enumerate(self.all_input_filepaths):
-            if self.stop_processing:
-                return False
-            self.update_progress(
-                f"   Solving {idx + 1}/{total}: {os.path.basename(fpath)}",
-                5 + int(35 * (idx / max(total, 1))),
-            )
+
+        def _solve_single(path):
             try:
-                hdr = fits.getheader(fpath, memmap=False)
+                hdr_local = fits.getheader(path, memmap=False)
                 if self.astrometry_solver:
-                    wcs_obj = self.astrometry_solver.solve(
-                        fpath, hdr, solver_settings, update_header_with_solution=False
+                    wcs_obj_local = self.astrometry_solver.solve(
+                        path, hdr_local, solver_settings, update_header_with_solution=False
                     )
                 else:
-                    wcs_obj = solve_image_wcs(
-                        fpath, hdr, solver_settings, update_header_with_solution=False
+                    wcs_obj_local = solve_image_wcs(
+                        path, hdr_local, solver_settings, update_header_with_solution=False
                     )
-                if wcs_obj and wcs_obj.is_celestial:
+                return path, hdr_local, wcs_obj_local, None
+            except Exception as exc:
+                return path, None, None, exc
+
+        max_workers = max(1, (os.cpu_count() or 1) // 2)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = [ex.submit(_solve_single, fp) for fp in self.all_input_filepaths]
+            for idx, fut in enumerate(concurrent.futures.as_completed(futures), 1):
+                if self.stop_processing:
+                    for f in futures:
+                        f.cancel()
+                    return False
+                fpath, hdr, wcs_obj, err = fut.result()
+                self.update_progress(
+                    f"   Solving {idx}/{total}: {os.path.basename(fpath)}",
+                    5 + int(35 * ((idx - 1) / max(total, 1))),
+                )
+                if err is not None:
+                    self.update_progress(
+                        f"⚠️ [Pré-scan] Erreur WCS sur {os.path.basename(fpath)}: {err}",
+                        "WARN",
+                    )
+                elif wcs_obj and wcs_obj.is_celestial:
                     wcs_list.append(wcs_obj)
                     header_list.append(hdr)
                 else:
@@ -1630,11 +1655,6 @@ class SeestarQueuedStacker:
                         f"⚠️ [Pré-scan] Échec résolution pour {os.path.basename(fpath)}",
                         "WARN",
                     )
-            except Exception as e:
-                self.update_progress(
-                    f"⚠️ [Pré-scan] Erreur WCS sur {os.path.basename(fpath)}: {e}",
-                    "WARN",
-                )
 
         if not wcs_list:
             self.update_progress(
@@ -2114,23 +2134,35 @@ class SeestarQueuedStacker:
             logger.debug(f"!!!! DEBUG _worker APRÈS BLOC IF/ELIF POUR SOLVING ANCRE (SECTION 1.A) !!!! self.is_mosaic_run = {self.is_mosaic_run}")
 
             # --- Initialisation grille Drizzle Standard (si applicable pour un run NON-mosaïque) ---
-            if self.drizzle_active_session and not self.is_mosaic_run: 
-                self.update_progress("DEBUG WORKER: Initialisation grille de sortie pour Drizzle Standard...", "DEBUG_DETAIL")
+            if self.drizzle_active_session and not self.is_mosaic_run:
+                self.update_progress(
+                    "DEBUG WORKER: Initialisation grille de sortie pour Drizzle Standard...",
+                    "DEBUG_DETAIL",
+                )
                 if self.reference_wcs_object and hasattr(reference_image_data_for_global_alignment, 'shape'):
                     ref_shape_for_drizzle_grid_hw = reference_image_data_for_global_alignment.shape[:2]
                     try:
-                        self.drizzle_output_wcs, self.drizzle_output_shape_hw = self._create_drizzle_output_wcs(
-                            self.reference_wcs_object,      
-                            ref_shape_for_drizzle_grid_hw,  
-                            self.drizzle_scale              
-                        )
                         if self.drizzle_output_wcs is None or self.drizzle_output_shape_hw is None:
-                            raise RuntimeError("Échec de _create_drizzle_output_wcs (retourne None) pour Drizzle Standard.")
-                        logger.debug(f"DEBUG QM [_worker]: Grille de sortie Drizzle Standard initialisée: Shape={self.drizzle_output_shape_hw}")
-                        self.update_progress(f"   Grille Drizzle Standard prête: {self.drizzle_output_shape_hw}", "INFO")
+                            self.drizzle_output_wcs, self.drizzle_output_shape_hw = self._create_drizzle_output_wcs(
+                                self.reference_wcs_object,
+                                ref_shape_for_drizzle_grid_hw,
+                                self.drizzle_scale,
+                            )
+                            if self.drizzle_output_wcs is None or self.drizzle_output_shape_hw is None:
+                                raise RuntimeError(
+                                    "Échec de _create_drizzle_output_wcs (retourne None) pour Drizzle Standard."
+                                )
+                        logger.debug(
+                            f"DEBUG QM [_worker]: Grille de sortie Drizzle Standard initialisée: Shape={self.drizzle_output_shape_hw}"
+                        )
+                        self.update_progress(
+                            f"   Grille Drizzle Standard prête: {self.drizzle_output_shape_hw}",
+                            "INFO",
+                        )
                     except Exception as e_grid_driz:
                         error_msg_grid = f"Échec critique création grille de sortie Drizzle Standard: {e_grid_driz}"
-                        self.update_progress(error_msg_grid, "ERROR"); raise RuntimeError(error_msg_grid)
+                        self.update_progress(error_msg_grid, "ERROR")
+                        raise RuntimeError(error_msg_grid)
                 else:
                     error_msg_ref_driz = "Référence WCS ou shape de l'image de référence globale manquante pour initialiser la grille Drizzle Standard."
                     self.update_progress(error_msg_ref_driz, "ERROR"); raise RuntimeError(error_msg_ref_driz)
@@ -2140,14 +2172,6 @@ class SeestarQueuedStacker:
             self.update_progress("DEBUG WORKER: Fin Section 1 (Préparation Référence).") # Message plus général
             self.update_progress("⭐ Référence(s) prête(s).", 5)
             self._recalculate_total_batches()
-
-            ok_grid = True
-            if self.reproject_between_batches and self.fixed_output_wcs is None:
-                ok_grid = self._prepare_global_reprojection_grid()
-                if not ok_grid:
-                    self.update_progress("❌ Failed to initialise global WCS grid", "ERROR")
-                    self.stop_processing = True
-                    return
 
             self.update_progress(
                 f"▶️ Démarrage boucle principale (En file: {self.files_in_queue} | Lots Estimés: {self.total_batches_estimated if self.total_batches_estimated > 0 else '?'})..."
@@ -3277,11 +3301,15 @@ class SeestarQueuedStacker:
             )
             return
 
-        output_wcs, output_shape_hw = self._calculate_final_mosaic_grid(
-            all_wcs_for_grid_calc,
-            all_headers_for_grid_calc,
-            scale_factor=self.drizzle_scale if self.drizzle_active_session else 1.0,
-        )
+        if self.reference_wcs_object is not None and self.reference_shape is not None:
+            output_wcs = self.reference_wcs_object
+            output_shape_hw = self.reference_shape
+        else:
+            output_wcs, output_shape_hw = self._calculate_final_mosaic_grid(
+                all_wcs_for_grid_calc,
+                all_headers_for_grid_calc,
+                scale_factor=self.drizzle_scale if self.drizzle_active_session else 1.0,
+            )
 
         if output_wcs is None or output_shape_hw is None:
             self.update_progress(
@@ -5853,7 +5881,15 @@ class SeestarQueuedStacker:
         self.update_progress(f"  DEBUG QM [SaveFinalStack] final_image_initial_raw (AVANT post-traitements) - Range: [{np.nanmin(final_image_initial_raw):.4g}, {np.nanmax(final_image_initial_raw):.4g}], Shape: {final_image_initial_raw.shape}, Dtype: {final_image_initial_raw.dtype}")
         logger.debug(f"  DEBUG QM [SaveFinalStack] final_image_initial_raw (AVANT post-traitements) - Range: [{np.nanmin(final_image_initial_raw):.4g}, {np.nanmax(final_image_initial_raw):.4g}], Shape: {final_image_initial_raw.shape}, Dtype: {final_image_initial_raw.dtype}")
 
-        if is_classic_reproject_mode and final_wht_map_for_postproc is not None:
+        if (
+            final_wht_map_for_postproc is not None
+            and (
+                is_classic_reproject_mode
+                or is_reproject_mosaic_mode
+                or is_true_incremental_drizzle_from_objects
+                or is_drizzle_final_mode_with_data
+            )
+        ):
             rows, cols = np.where(final_wht_map_for_postproc > 0)
             if rows.size and cols.size:
                 y0, y1 = rows.min(), rows.max() + 1
@@ -6242,7 +6278,12 @@ class SeestarQueuedStacker:
 ################################################################################################################################################
 
     def add_folder(self, folder_path):
-        if not self.processing_active: self.update_progress("ⓘ Impossible d'ajouter un dossier, traitement non actif."); return False
+        if not self.processing_active:
+            self.update_progress("ⓘ Impossible d'ajouter un dossier, traitement non actif.")
+            return False
+        if self.reproject_between_batches:
+            self.update_progress("⚠️ Reprojection active : ajout de dossier désactivé")
+            return False
         abs_path = os.path.abspath(folder_path)
         if not os.path.isdir(abs_path): self.update_progress(f"❌ Dossier non trouvé: {folder_path}"); return False
         output_abs = os.path.abspath(self.output_folder) if self.output_folder else None
@@ -6567,40 +6608,6 @@ class SeestarQueuedStacker:
         self.update_progress(f"ⓘ Taille de lot effective pour le traitement : {self.batch_size}")
         logger.debug("DEBUG QM (start_processing): Fin Étape 1 - Configuration des paramètres de session.")
 
-        # --- NEW STEP: Pre-scan headers to compute a fixed output grid ---
-        if self.reproject_between_batches:
-            all_paths = []
-            if self.current_folder and os.path.isdir(self.current_folder):
-                for fn in sorted(os.listdir(self.current_folder)):
-                    if fn.lower().endswith((".fit", ".fits")):
-                        all_paths.append(os.path.join(self.current_folder, fn))
-            if initial_additional_folders:
-                for f in initial_additional_folders:
-                    abs_f = os.path.abspath(str(f))
-                    if os.path.isdir(abs_f):
-                        for fn in sorted(os.listdir(abs_f)):
-                            if fn.lower().endswith((".fit", ".fits")):
-                                all_paths.append(os.path.join(abs_f, fn))
-            from ..core.reprojection_utils import collect_headers, compute_final_output_grid
-            header_infos = collect_headers(all_paths)
-            if header_infos:
-                try:
-                    self.fixed_output_wcs, self.fixed_output_shape = compute_final_output_grid(
-                        header_infos, scale=self.drizzle_scale
-                    )
-
-
-                    self.reference_shape = self.fixed_output_shape
-                    self.update_progress(
-                        f"🗺️ Grille fixe calculée {self.fixed_output_shape} px.",
-                        None,
-                    )
-                except Exception as e_grid:
-                    self.update_progress(f"⚠️ Erreur calcul grille fixe: {e_grid}", "WARN")
-            self.all_input_filepaths = all_paths
-
-
-
         # --- ÉTAPE 2 : PRÉPARATION DE L'IMAGE DE RÉFÉRENCE (shape ET WCS global si nécessaire) ---
         # ... (le reste de la méthode est inchangé) ...
         logger.debug("DEBUG QM (start_processing): Étape 2 - Préparation référence (shape ET WCS global si Drizzle/Mosaïque)...")
@@ -6827,14 +6834,24 @@ class SeestarQueuedStacker:
 
 
 
-        initial_files_added = self._add_files_to_queue(self.current_folder) 
-        if initial_files_added > 0: 
+        initial_files_added = self._add_files_to_queue(self.current_folder)
+        if initial_files_added > 0:
             self._recalculate_total_batches()
             self.update_progress(f"📋 {initial_files_added} fichiers initiaux ajoutés. Total lots estimé: {self.total_batches_estimated if self.total_batches_estimated > 0 else '?'}")
-        elif not self.additional_folders: 
+        elif not self.additional_folders:
             self.update_progress("⚠️ Aucun fichier initial trouvé dans le dossier principal et aucun dossier supplémentaire en attente.")
-        
-        self.aligner.reference_image_path = reference_path_ui or None 
+
+        if self.reproject_between_batches:
+            ok_grid = self._prepare_global_reprojection_grid()
+            if not ok_grid:
+                return False
+            self.fixed_output_wcs = self.reference_wcs_object
+            self.fixed_output_shape = self.reference_shape
+            if self.drizzle_active_session:
+                self.drizzle_output_wcs = self.reference_wcs_object
+                self.drizzle_output_shape_hw = self.reference_shape
+
+        self.aligner.reference_image_path = reference_path_ui or None
 
         logger.debug("DEBUG QM (start_processing V_StartProcessing_SaveDtypeOption_1): Démarrage du thread worker...") # Version Log
         self.processing_thread = threading.Thread(target=self._worker, name="StackerWorker")


### PR DESCRIPTION
## Summary
- remove header-based grid estimate
- always calculate the global WCS grid before launching the worker
- reuse computed grid during initialize and worker phases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdcb9cbf8832f9911feb84ab21b66