### PR TITLE
Implement move-to-stacked and periodic partial saves

### DIFF
--- a/seestar/tools/__init__.py
+++ b/seestar/tools/__init__.py
@@ -8,9 +8,10 @@ from .stretch import (
      ColorCorrection,
      apply_auto_stretch,
      apply_auto_white_balance,
-     apply_enhanced_stretch, # Keep if needed
-     save_fits_as_png
+     apply_enhanced_stretch,  # Keep if needed
+     save_fits_as_png,
 )
+from .file_ops import move_to_stacked
 
 # Optionally import visu if you want it accessible via seestar.tools.visu (though it's standalone)
 # from . import visu
@@ -23,7 +24,8 @@ __all__ = [
      'apply_auto_stretch',
      'apply_auto_white_balance',
      'apply_enhanced_stretch',
-     'save_fits_as_png'
+     'save_fits_as_png',
+     'move_to_stacked'
      # Add 'visu', 'testimg' here if you import and want to expose them
      ]
 # --- END OF FILE seestar/tools/__init__.py ---

--- a/seestar/tools/file_ops.py
+++ b/seestar/tools/file_ops.py
@@ -1,0 +1,31 @@
+import os
+import shutil
+import time
+from typing import Iterable, Callable
+
+
+def move_to_stacked(paths: Iterable[str], progress_cb: Callable[[str, str | None], None] | None = None, subdir: str = "stacked") -> None:
+    """Move processed RAW files to a sibling 'stacked' folder."""
+    for p in paths:
+        if not p or not os.path.exists(p):
+            continue
+        src_dir = os.path.dirname(os.path.abspath(p))
+        dst_dir = os.path.join(src_dir, subdir)
+        os.makedirs(dst_dir, exist_ok=True)
+        base = os.path.basename(p)
+        dst = os.path.join(dst_dir, base)
+        if os.path.exists(dst):
+            stem, ext = os.path.splitext(base)
+            dst = os.path.join(dst_dir, f"{stem}_dup_{int(time.time())}{ext}")
+        try:
+            same_dev = os.stat(src_dir).st_dev == os.stat(dst_dir).st_dev
+            if same_dev:
+                os.rename(p, dst)
+            else:
+                shutil.copy2(p, dst)
+                os.remove(p)
+            if progress_cb:
+                progress_cb(f"📦 Moved to stacked: {base}", "INFO_DETAIL")
+        except Exception as e:
+            if progress_cb:
+                progress_cb(f"⚠️ Move failed for {base}: {e}", "WARN")


### PR DESCRIPTION
## Summary
- add `move_to_stacked` helper to relocate processed files
- expose helper from `seestar.tools`
- track raw paths and move them after each batch
- periodically write partial FITS stacks and persist batch count
- allow resuming from existing memmaps
- skip already stacked files when scanning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b9abbb14832f9737ce648a064d77