### PR TITLE
Support additional stacking modes and normalization

### DIFF
--- a/seestar/core/__init__.py
+++ b/seestar/core/__init__.py
@@ -17,6 +17,16 @@ from .weights import (
     _calculate_image_weights_noise_variance,
     _calculate_image_weights_noise_fwhm,
 )
+from .normalization import (
+    _normalize_images_linear_fit,
+    _normalize_images_sky_mean,
+)
+from .stack_methods import (
+    _stack_mean,
+    _stack_median,
+    _stack_kappa_sigma,
+    _stack_linear_fit_clip,
+)
 from .incremental_reprojection import reproject_and_combine
 from .reprojection import resolve_all_wcs
 from .reprojection_utils import collect_headers, compute_final_output_grid
@@ -36,6 +46,12 @@ __all__ = [
     'SeestarAligner',         # L'aligneur astroalign
     '_calculate_image_weights_noise_variance',
     '_calculate_image_weights_noise_fwhm',
+    '_normalize_images_linear_fit',
+    '_normalize_images_sky_mean',
+    '_stack_mean',
+    '_stack_median',
+    '_stack_kappa_sigma',
+    '_stack_linear_fit_clip',
     'create_master_tile_simple',
     'reproject_and_combine',
     'resolve_all_wcs',

--- a/seestar/core/normalization.py
+++ b/seestar/core/normalization.py
@@ -1,0 +1,63 @@
+"""Image normalisation utilities duplicated from ZeMosaic."""
+import numpy as np
+
+
+def _normalize_images_linear_fit(image_list, reference_index=0, low_percentile=25.0, high_percentile=90.0):
+    if not image_list or not (0 <= reference_index < len(image_list)):
+        return [img.copy() if img is not None else None for img in image_list]
+    ref = image_list[reference_index]
+    if ref is None:
+        return [img.copy() if img is not None else None for img in image_list]
+    ref = ref.astype(np.float32, copy=False)
+    is_color = ref.ndim == 3 and ref.shape[-1] == 3
+    ref_low = np.nanpercentile(ref, low_percentile, axis=(0, 1) if is_color else None)
+    ref_high = np.nanpercentile(ref, high_percentile, axis=(0, 1) if is_color else None)
+    normalized = []
+    for i, img in enumerate(image_list):
+        if img is None:
+            normalized.append(None)
+            continue
+        data = img.astype(np.float32, copy=True)
+        if i == reference_index:
+            normalized.append(data)
+            continue
+        low = np.nanpercentile(data, low_percentile, axis=(0, 1) if is_color else None)
+        high = np.nanpercentile(data, high_percentile, axis=(0, 1) if is_color else None)
+        delta_src = high - low
+        delta_ref = ref_high - ref_low
+        a = np.where(delta_src > 1e-5, delta_ref / np.maximum(delta_src, 1e-9), 1.0)
+        b = ref_low - a * low
+        data = a * data + b
+        normalized.append(data)
+    return normalized
+
+
+def _normalize_images_sky_mean(image_list, reference_index=0, sky_percentile=25.0):
+    if not image_list or not (0 <= reference_index < len(image_list)):
+        return [img.copy() if img is not None else None for img in image_list]
+    ref = image_list[reference_index]
+    if ref is None:
+        return [img.copy() if img is not None else None for img in image_list]
+    ref = ref.astype(np.float32, copy=False)
+    if ref.ndim == 3 and ref.shape[-1] == 3:
+        ref_lum = 0.299 * ref[..., 0] + 0.587 * ref[..., 1] + 0.114 * ref[..., 2]
+    else:
+        ref_lum = ref
+    ref_sky = np.nanpercentile(ref_lum, sky_percentile)
+    normalized = []
+    for i, img in enumerate(image_list):
+        if img is None:
+            normalized.append(None)
+            continue
+        data = img.astype(np.float32, copy=True)
+        if i == reference_index:
+            normalized.append(data)
+            continue
+        if data.ndim == 3 and data.shape[-1] == 3:
+            lum = 0.299 * data[..., 0] + 0.587 * data[..., 1] + 0.114 * data[..., 2]
+        else:
+            lum = data
+        curr_sky = np.nanpercentile(lum, sky_percentile)
+        data += ref_sky - curr_sky
+        normalized.append(data)
+    return normalized

--- a/seestar/core/stack_methods.py
+++ b/seestar/core/stack_methods.py
@@ -1,0 +1,66 @@
+# Stacking algorithms duplicated from ZeMosaic
+
+import numpy as np
+
+
+def _stack_mean(images, weights=None):
+    arr = np.stack([im for im in images], axis=0).astype(np.float32)
+    if weights is not None:
+        w = np.asarray(weights, dtype=np.float32)[:, None, None]
+        if arr.ndim == 4:
+            w = w[..., None]
+        sum_w = np.sum(w, axis=0)
+        sum_d = np.sum(arr * w, axis=0)
+        result = np.divide(sum_d, sum_w, out=np.zeros_like(sum_d), where=sum_w > 1e-9)
+    else:
+        result = np.mean(arr, axis=0)
+    return result.astype(np.float32), 0.0
+
+
+def _stack_median(images, _weights=None):
+    arr = np.stack([im for im in images], axis=0).astype(np.float32)
+    result = np.median(arr, axis=0)
+    return result.astype(np.float32), 0.0
+
+
+def _stack_kappa_sigma(images, weights=None, sigma_low=3.0, sigma_high=3.0):
+    arr = np.stack([im for im in images], axis=0).astype(np.float32)
+    med = np.median(arr, axis=0)
+    std = np.std(arr, axis=0)
+    low = med - sigma_low * std
+    high = med + sigma_high * std
+    mask = (arr >= low) & (arr <= high)
+    arr_clip = np.where(mask, arr, np.nan)
+    if weights is not None:
+        w = np.asarray(weights, dtype=np.float32)[:, None, None]
+        if arr.ndim == 4:
+            w = w[..., None]
+        sum_w = np.nansum(w * mask, axis=0)
+        sum_d = np.nansum(arr_clip * w, axis=0)
+        result = np.divide(sum_d, sum_w, out=np.zeros_like(sum_d), where=sum_w > 1e-6)
+    else:
+        result = np.nanmean(arr_clip, axis=0)
+    rejected_pct = 100.0 * (mask.size - np.count_nonzero(mask)) / float(mask.size)
+    return result.astype(np.float32), rejected_pct
+
+
+def _stack_linear_fit_clip(images, weights=None, sigma=3.0):
+    arr = np.stack([im for im in images], axis=0).astype(np.float32)
+    median = np.median(arr, axis=0)
+    residuals = arr - median
+    med_res = np.median(residuals, axis=0)
+    std_res = np.std(residuals, axis=0)
+    mask = np.abs(residuals - med_res) <= sigma * std_res
+    arr_clip = np.where(mask, arr, np.nan)
+    if weights is not None:
+        w = np.asarray(weights, dtype=np.float32)[:, None, None]
+        if arr.ndim == 4:
+            w = w[..., None]
+        sum_w = np.nansum(w * mask, axis=0)
+        sum_d = np.nansum(arr_clip * w, axis=0)
+        result = np.divide(sum_d, sum_w, out=np.zeros_like(sum_d), where=sum_w > 1e-6)
+    else:
+        result = np.nanmean(arr_clip, axis=0)
+    rejected_pct = 100.0 * (mask.size - np.count_nonzero(mask)) / float(mask.size)
+    return result.astype(np.float32), rejected_pct
+


### PR DESCRIPTION
## Summary
- duplicate ZeMosaic normalization helpers into Seestar
- implement simple stacking algorithms
- wire new normalize/weight/stack options in queue manager
- expose methods from `core`
- log selected stacking settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685418ee370c832fb569423c98f9a592