### PR TITLE
Refactor inter-batch stacking

### DIFF
--- a/tests/test_incremental_reprojection.py
+++ b/tests/test_incremental_reprojection.py
@@ -30,7 +30,7 @@ if "seestar.gui" not in sys.modules:
     sys.modules["seestar"] = seestar_pkg
     sys.modules["seestar.gui"] = gui_pkg
     sys.modules["seestar.gui.settings"] = settings_mod
-sys.modules["seestar.gui.histogram_widget"] = hist_mod
+    sys.modules["seestar.gui.histogram_widget"] = hist_mod
 
 spec = importlib.util.spec_from_file_location(
     "seestar.enhancement.reproject_utils",

--- a/tests/test_queue_manager_reproject.py
+++ b/tests/test_queue_manager_reproject.py
@@ -59,7 +59,7 @@ class DummyStacker:
     def _combine_batch_result(self, data, header, coverage, batch_wcs=None):
         batch_sum = data.astype(np.float32)
         batch_wht = coverage.astype(np.float32)
-        if not self.reproject_between_batches and self.reference_wcs_object and batch_wcs is not None:
+        if self.reproject_between_batches and self.reference_wcs_object and batch_wcs is not None:
             reproject_interp = reproject_utils.reproject_interp
             shp = self.memmap_shape[:2]
             if batch_sum.ndim == 3:
@@ -99,14 +99,14 @@ def test_combine_batch_respects_flag(monkeypatch):
     monkeypatch.setattr(reproject_utils, "reproject_interp", fake_reproj)
     s.reproject_between_batches = False
     s._combine_batch_result(img, fits.Header(), cov, wcs_in)
-    assert calls["n"] > 0
+    assert calls["n"] == 0
 
     calls["n"] = 0
     s.cumulative_sum_memmap.fill(0)
     s.cumulative_wht_memmap.fill(0)
     s.reproject_between_batches = True
     s._combine_batch_result(img, fits.Header(), cov, wcs_in)
-    assert calls["n"] == 0
+    assert calls["n"] > 0
 
 
 def test_process_file_returns_wcs_when_reproject(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- reproject stacked batches in `queue_manager._combine_batch_result`
- refactor worker loop to stack batches then reproject once
- prevent plate solving of single frames in inter-batch mode
- fix tests for new behaviour

## Testing
- `pytest -q` *(fails: tests/test_mosaic_worker.py::test_resolve_after_crop)*

------
https://chatgpt.com/codex/tasks/task_e_685475fdafe0832faa8f576b6a0ff9ce