### PR TITLE
Restore single-solve interbatch workflow

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3268,10 +3268,14 @@ class SeestarQueuedStacker:
                         logger.debug(
                             f"  DEBUG _worker (iter {iteration_count}): Entrée branche 'Stacking Classique/Drizzle Standard' pour _process_file."
                         )
+                        solve_astrometry = False
+                        if self.reproject_between_batches and not current_batch_items_with_masks_for_stack_batch:
+                            solve_astrometry = True
+
                         item_result_tuple = self._process_file(
                             file_path,
                             reference_image_data_for_global_alignment,
-                            solve_astrometry_for_this_file=False,
+                            solve_astrometry_for_this_file=solve_astrometry,
                         )
                         self.processed_files_count += 1
                         if (


### PR DESCRIPTION
## Summary
- re-enable solving the first image of each batch when `reproject_between_batches` is active
- avoid per-file solves while still solving stacked batch once

## Testing
- `pytest tests/test_queue_manager_reproject.py::test_process_file_returns_wcs_when_reproject -q`
- `pytest tests/test_queue_manager_reproject.py::test_process_file_skips_solver_when_disabled -q`


------
https://chatgpt.com/codex/tasks/task_e_685482c479bc832fa2a9bf1393bf8ddb