### PR TITLE
Update inter-batch reprojection logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,9 +349,10 @@ zemosaic_worker.run_hierarchical_mosaic(
 - `api_key`: astrometry.net API key
 - `local_solver_preference`: preferred local solver (`astap` or `ansvr`)
 
-- `reproject_between_batches`: when true, each stacked batch is plate-solved and
-  immediately reprojected onto the reference WCS. The master stack is updated
-  incrementally so no final reprojection step is required.
+- `reproject_between_batches`: when enabled the frames of each batch are first
+  stacked. The resulting stack is solved once with ASTAP and reprojected onto
+  the reference WCS obtained from the first solved batch. Individual images are
+  never sent to the solver.
 
 `use_radec_hints` controls whether ASTAP receives the RA/DEC coordinates from
 the FITS header. This option is **disabled by default** and should only be

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -2933,7 +2933,18 @@ class SeestarQueuedStacker:
                 self.update_progress(
                     "DEBUG WORKER: Branche Drizzle Std / AstroMosaic / ReprojectBatches pour référence globale..."
                 )
-                if self.astrometry_solver and os.path.exists(
+
+                if (
+                    self.reproject_between_batches
+                    and not self.drizzle_active_session
+                    and not self.is_mosaic_run
+                ):
+                    self.update_progress(
+                        "   -> Reproject entre lots actif: résolution de la référence reportée au premier stack",
+                        "INFO_DETAIL",
+                    )
+                    self.reference_wcs_object = None
+                elif self.astrometry_solver and os.path.exists(
                     reference_image_path_for_solver
                 ):
                     self.update_progress(
@@ -3273,6 +3284,7 @@ class SeestarQueuedStacker:
                         solve_astrometry = False
                         if (
                             self.reproject_between_batches
+                            and self.drizzle_active_session
                             and not current_batch_items_with_masks_for_stack_batch
                         ):
                             solve_astrometry = True


### PR DESCRIPTION
## Summary
- update `reproject_between_batches` description in README
- skip initial reference solve when stacking classic batches
- only solve first frame of batch when drizzling
- adjust mosaic worker tests for new helper signatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685496dff824832fb312ed66e4635cbc