### PR TITLE
Fix mask selection for classic reproject batch mode

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3307,8 +3307,17 @@ class SeestarQueuedStacker:
                                 # store only the components expected by
                                 # ``_stack_batch`` (data, header, scores,
                                 # wcs_object, valid_mask)
+                                # _stack_batch expects (data, header, scores, wcs, valid_mask)
+                                # item_result_tuple structure is
+                                # (data, header, scores, wcs, matrix_M, valid_mask)
                                 current_batch_items_with_masks_for_stack_batch.append(
-                                    item_result_tuple[:5]
+                                    (
+                                        item_result_tuple[0],
+                                        item_result_tuple[1],
+                                        item_result_tuple[2],
+                                        item_result_tuple[3],
+                                        item_result_tuple[5],
+                                    )
                                 )
                                 self._current_batch_paths.append(file_path)
 


### PR DESCRIPTION
## Summary
- ensure `_worker` passes the correct mask element when preparing batch tuples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549ef6d1c4832fad3f3b62f8e1df36