### PR TITLE
Introduce solve_batches flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ zemosaic_worker.run_hierarchical_mosaic(
 - `freeze_reference_wcs`: when set to `true` the reference WCS determined from
   the first solved batch remains fixed for the whole run, preventing small
   drifts between batches when using inter-batch reprojection.
+- `solve_batches`: disable solving of each stacked batch when set to `false`.
+  The stored reference WCS header is applied instead.
 
 `use_radec_hints` controls whether ASTAP receives the RA/DEC coordinates from
 the FITS header. This option is **disabled by default** and should only be


### PR DESCRIPTION
## Summary
- allow disabling solving of intermediate batches
- reference docs on solve_batches
- add `solve_batches` attribute and logic in queue manager
- bypass solver when solve_batches is False
- test new flag in queue manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685515e3dbc0832f9a151d3063c7b766