### PR TITLE
Fix batch solving when reprojecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,13 +349,15 @@ zemosaic_worker.run_hierarchical_mosaic(
 - `api_key`: astrometry.net API key
 - `local_solver_preference`: preferred local solver (`astap` or `ansvr`)
 
-- `reproject_between_batches`: when enabled the frames of each batch are first
-  stacked. The resulting stack is solved once with ASTAP and reprojected onto
-  the reference WCS obtained from the first solved batch. Individual images are
-  never sent to the solver.
-- `freeze_reference_wcs`: when set to `true` the reference WCS determined from
-  the first solved batch remains fixed for the whole run, preventing small
-  drifts between batches when using inter-batch reprojection.
+- `reproject_between_batches`: when enabled the frames of each batch are stacked
+  and reprojected onto the reference WCS solved from the initial reference
+  image. Intermediate stacks are not solved again unless `solve_batches` is
+  `true`.
+- `freeze_reference_wcs`: when `true` the reference WCS determined from the
+  first solved batch remains fixed for the whole run, preventing small drifts
+  between batches when using inter-batch reprojection. This is automatically
+  enabled when `reproject_between_batches` is used unless explicitly set to
+  `false` before starting the process.
 - `solve_batches`: disable solving of each stacked batch when set to `false`.
   The stored reference WCS header is applied instead.
 
@@ -367,10 +369,11 @@ performs a blind search centered only on the provided search radius.
 ### Inter-Batch Reprojection with Constant WCS
 
 You can reproject each stacked batch without solving them all. Enable
-`reproject_between_batches` and set `solve_batches` to `false` so only the first
-batch is solved. Setting `freeze_reference_wcs` to `true` keeps that initial WCS
-for the rest of the run. Subsequent batches are reprojected using a new
-fixed-orientation grid so the image orientation stays constant and small
+`reproject_between_batches` and set `solve_batches` to `false` so only the
+reference image is solved once at the start. `freeze_reference_wcs` will be
+turned on automatically in this mode (unless you disable it explicitly) so the
+initial WCS is reused for every batch. Subsequent batches are reprojected using
+a new fixed-orientation grid so the image orientation stays constant and small
 rotation drifts are eliminated.
 
 ---

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -2997,6 +2997,7 @@ class SeestarQueuedStacker:
 
                 if (
                     self.reproject_between_batches
+                    and not self.freeze_reference_wcs
                     and not self.drizzle_active_session
                     and not self.is_mosaic_run
                 ):
@@ -9959,8 +9960,15 @@ class SeestarQueuedStacker:
         )
 
         self.reproject_between_batches = bool(reproject_between_batches)
-        # Disable solving of intermediate batches when reprojection is used and
-        # the reference WCS should remain fixed.
+        # When inter-batch reprojection is requested we typically want to keep
+        # the reference WCS stable. If the caller did not explicitly set
+        # ``freeze_reference_wcs`` beforehand, enable it automatically so that
+        # intermediate batches are not solved again.
+        if self.reproject_between_batches and not self.freeze_reference_wcs:
+            self.freeze_reference_wcs = True
+
+        # Disable solving of intermediate batches when reprojection is active
+        # and the reference WCS should remain fixed.
         self.solve_batches = not (
             self.reproject_between_batches and self.freeze_reference_wcs
         )


### PR DESCRIPTION
## Summary
- ensure reference solving is not postponed when the WCS is frozen
- clarify `reproject_between_batches` doc

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855143437f8832fbcf0c495a0600cfc