### PR TITLE
Fix preview refresh with inter-batch reprojection

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3427,6 +3427,12 @@ class SeestarQueuedStacker:
                                             wht_2d,
                                             batch_wcs=batch_wcs,
                                         )
+                                        if hasattr(self.cumulative_sum_memmap, "flush"):
+                                            self.cumulative_sum_memmap.flush()
+                                        if hasattr(self.cumulative_wht_memmap, "flush"):
+                                            self.cumulative_wht_memmap.flush()
+                                        if not self.drizzle_active_session:
+                                            self._update_preview_sum_w()
 
                                         # After accumulation, solve the cumulative stack
                                         if self.reproject_between_batches:


### PR DESCRIPTION
## Summary
- ensure preview is refreshed when stacking with `reproject_between_batches`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685530772fb4832f950290539704e9a2