### PR TITLE
Add CUDA GPU enforcement utilities and integrate in launch scripts

### DIFF
--- a/seestar/core/cuda_utils.py
+++ b/seestar/core/cuda_utils.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+
+
+def enforce_nvidia_gpu():
+    """Force l'utilisation du premier GPU NVIDIA disponible via CUDA_VISIBLE_DEVICES.
+
+    Returns:
+        bool: True si la variable a été définie avec succès, False sinon.
+    """
+    try:
+        output = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        first_index = output.strip().splitlines()[0]
+        if first_index:
+            os.environ["CUDA_VISIBLE_DEVICES"] = first_index
+            return True
+    except Exception:
+        pass
+    return False
+

--- a/seestar/main.py
+++ b/seestar/main.py
@@ -13,7 +13,14 @@ from astropy.io.fits.verify import VerifyWarning
 import argparse
 import logging
 
+# NVIDIA GPU enforcement before importing CUDA libraries
+from seestar.core.cuda_utils import enforce_nvidia_gpu
+
 logger = logging.getLogger(__name__)
+
+# Force NVIDIA GPU selection if available
+gpu_set = enforce_nvidia_gpu()
+print("GPU NVIDIA forc\u00e9" if gpu_set else "Aucun GPU NVIDIA d\u00e9tect\u00e9")
 
 # --- MODIFIED Robust PYTHONPATH Modification ---
 try:

--- a/zemosaic/cuda_utils.py
+++ b/zemosaic/cuda_utils.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+
+
+def enforce_nvidia_gpu():
+    """Force l'utilisation du premier GPU NVIDIA via CUDA_VISIBLE_DEVICES."""
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        idx = out.strip().splitlines()[0]
+        if idx:
+            os.environ["CUDA_VISIBLE_DEVICES"] = idx
+            return True
+    except Exception:
+        pass
+    return False
+

--- a/zemosaic/run_zemosaic.py
+++ b/zemosaic/run_zemosaic.py
@@ -4,11 +4,18 @@ import sys # Ajout pour sys.path et sys.modules
 import tkinter as tk
 from tkinter import messagebox # Nécessaire pour la messagebox d'erreur critique
 
+# NVIDIA GPU enforcement before importing CUDA libraries
+from .cuda_utils import enforce_nvidia_gpu
+
 # --- Impression de débogage initiale ---
 print("--- run_zemosaic.py: DÉBUT DES IMPORTS ---")
 print(f"Python Executable: {sys.executable}")
 print(f"Python Version: {sys.version}")
 print(f"Chemin de travail actuel (CWD): {sys.path[0]}") # sys.path[0] est généralement le dossier du script
+
+# Détection et forçage du GPU NVIDIA éventuel
+gpu_set = enforce_nvidia_gpu()
+print("GPU NVIDIA forcé" if gpu_set else "Aucun GPU NVIDIA détecté")
 
 # Essayer d'importer la classe GUI et la variable de disponibilité du worker
 try:


### PR DESCRIPTION
## Summary
- add `enforce_nvidia_gpu()` utility in both modules
- call the utility before importing heavy modules in `seestar/main.py`
- same GPU check before imports in `zemosaic/run_zemosaic.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685565f0d9d0832f845ff52c43d524ef