### PR TITLE
Add GPU enforcement util

### DIFF
--- a/seestar/core/cuda_utils.py
+++ b/seestar/core/cuda_utils.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+
+
+def enforce_nvidia_gpu():
+    """Force usage of the first NVIDIA GPU if available."""
+    try:
+        output = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        index = output.splitlines()[0].strip()
+        if index:
+            os.environ["CUDA_VISIBLE_DEVICES"] = index
+            return True
+    except Exception:
+        pass
+    return False

--- a/seestar/main.py
+++ b/seestar/main.py
@@ -65,6 +65,13 @@ except Exception as path_e:
     traceback.print_exc()
 # --- FIN MODIFIED ---
 
+from seestar.core.cuda_utils import enforce_nvidia_gpu
+
+if enforce_nvidia_gpu():
+    print(f"GPU NVIDIA forcée (CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES')})")
+else:
+    print("Aucun GPU NVIDIA détecté ou 'nvidia-smi' indisponible.")
+
 
 # --- Bloc de débogage des imports (gardé) ---
 # ... (identique à avant) ...

--- a/zemosaic/core/cuda_utils.py
+++ b/zemosaic/core/cuda_utils.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+
+
+def enforce_nvidia_gpu():
+    """Force usage of the first NVIDIA GPU if available."""
+    try:
+        output = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        index = output.splitlines()[0].strip()
+        if index:
+            os.environ["CUDA_VISIBLE_DEVICES"] = index
+            return True
+    except Exception:
+        pass
+    return False

--- a/zemosaic/run_zemosaic.py
+++ b/zemosaic/run_zemosaic.py
@@ -1,14 +1,21 @@
 # zemosaic/run_zemosaic.py
 import sys # Ajout pour sys.path et sys.modules
 # import reproject # L'import direct ici n'est pas crucial, mais ne fait pas de mal
+import os
 import tkinter as tk
 from tkinter import messagebox # Nécessaire pour la messagebox d'erreur critique
+from zemosaic.core.cuda_utils import enforce_nvidia_gpu
 
 # --- Impression de débogage initiale ---
 print("--- run_zemosaic.py: DÉBUT DES IMPORTS ---")
 print(f"Python Executable: {sys.executable}")
 print(f"Python Version: {sys.version}")
 print(f"Chemin de travail actuel (CWD): {sys.path[0]}") # sys.path[0] est généralement le dossier du script
+
+if enforce_nvidia_gpu():
+    print(f"GPU NVIDIA forcée (CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES')})")
+else:
+    print("Aucun GPU NVIDIA détecté ou 'nvidia-smi' indisponible.")
 
 # Essayer d'importer la classe GUI et la variable de disponibilité du worker
 try:


### PR DESCRIPTION
## Summary
- add CUDA visibility helpers for seestar and zemosaic
- call `enforce_nvidia_gpu` before any CUDA imports in main scripts
- fix import path to prevent `ModuleNotFoundError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685565f0d9d0832f845ff52c43d524ef