### PR TITLE
Add HQ RAM limit option

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -517,6 +517,7 @@ class SeestarStackerGUI:
         self.stacking_kappa_low_var = tk.DoubleVar(value=3.0)
         self.stacking_kappa_high_var = tk.DoubleVar(value=3.0)
         self.stacking_winsor_limits_str_var = tk.StringVar(value="0.05,0.05")
+        self.max_hq_mem_var = tk.DoubleVar(value=8)
         self.batch_size = tk.IntVar(value=10)
         self.correct_hot_pixels = tk.BooleanVar(value=True)
         self.hot_pixel_threshold = tk.DoubleVar(value=3.0)
@@ -1144,6 +1145,17 @@ class SeestarStackerGUI:
         )
         self.stack_final_combo.pack(side=tk.LEFT, padx=(5, 0))
         self.stack_final_combo.bind("<<ComboboxSelected>>", self._on_final_combo_change)
+
+        tk.Label(
+            final_frame,
+            text=self.tr("hq_ram_limit_label", default="HQ RAM limit (GB)")
+        ).pack(side=tk.LEFT, padx=(10, 2))
+        tk.Spinbox(
+            final_frame,
+            from_=1, to=64, increment=1,
+            width=5,
+            textvariable=self.max_hq_mem_var,
+        ).pack(side=tk.LEFT)
 
         # Mapping between internal keys and displayed labels for normalization, weighting and final combine
         self.norm_keys = ["none", "linear_fit", "sky_mean"]

--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -63,6 +63,7 @@ EN_TRANSLATIONS = {
     "stacking_winsor_limits_label": "Winsor Limits (low,high):",
     "stacking_winsor_note": "(e.g., 0.05,0.05 for 5% each side)",
     "stacking_final_combine_label": "Final Combine:",
+    "hq_ram_limit_label": "HQ RAM limit (GB)",
     "combine_method_mean": "Mean",
     "combine_method_median": "Median",
     "stack_method_label": "Method:",

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -63,6 +63,7 @@ FR_TRANSLATIONS = {
     "stacking_winsor_limits_label": "Limites Winsor (bas,haut) :",
     "stacking_winsor_note": "(ex : 0.05,0.05 pour 5% chaque côté)",
     "stacking_final_combine_label": "Combinaison Finale :",
+    "hq_ram_limit_label": "Limite RAM HQ (Go)",
     "combine_method_mean": "Moyenne",
     "combine_method_median": "Médiane",
     "stack_method_label": "Méthode :",


### PR DESCRIPTION
## Summary
- add localization string and spinbox for HQ RAM limit
- read and validate `max_hq_mem_gb` in settings
- propagate HQ memory limit to queue manager
- implement fallback combine by tiles for high quality combine
- enforce RAM check during drizzle batch combine

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a2cfbfc8832f9f87f2f704779c73