### PR TITLE
Improve winsorized sigma clipping logs

### DIFF
--- a/seestar/core/stack_methods.py
+++ b/seestar/core/stack_methods.py
@@ -1,6 +1,9 @@
 # Stacking algorithms duplicated from ZeMosaic
 
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def _stack_mean(images, weights=None):
@@ -73,6 +76,12 @@ def _stack_winsorized_sigma(
     apply_rewinsor=True,
 ):
     """Winsorized sigma clip stacking used by the queue manager."""
+    logger.debug(
+        "Winsorized sigma clip start: kappa=%s limits=%s apply_rewinsor=%s",
+        kappa,
+        winsor_limits,
+        apply_rewinsor,
+    )
     from scipy.stats.mstats import winsorize
     from astropy.stats import sigma_clipped_stats
 
@@ -101,5 +110,8 @@ def _stack_winsorized_sigma(
     else:
         result = np.nanmean(arr_clip, axis=0)
     rejected_pct = 100.0 * (mask.size - np.count_nonzero(mask)) / float(mask.size)
+    logger.debug("Winsorized sigma clip done: %.2f%% of pixels rejected",
+        rejected_pct,
+    )
     return result.astype(np.float32), rejected_pct
 

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -149,6 +149,7 @@ def _stack_worker(args):
         kappa_low,
         kappa_high,
         winsor_limits,
+        apply_rewinsor,
     ) = args
     os.environ["OMP_NUM_THREADS"] = "1"
 
@@ -166,6 +167,7 @@ def _stack_worker(args):
             weights,
             kappa=max(kappa_low, kappa_high),
             winsor_limits=winsor_limits,
+            apply_rewinsor=apply_rewinsor,
         )
     elif mode == "kappa-sigma":
         return _stack_kappa_sigma(
@@ -7447,6 +7449,10 @@ class SeestarQueuedStacker:
         apply_rewinsor=True,
     ):
         """Run winsorized sigma clipping in a separate process."""
+        self.update_progress(
+            f"RejWinsor: kappa={kappa}, limits={winsor_limits}, apply_rewinsor={apply_rewinsor}",
+            None,
+        )
         stack_args = (
             "winsorized-sigma",
             images,
@@ -7454,6 +7460,7 @@ class SeestarQueuedStacker:
             kappa,
             kappa,
             winsor_limits,
+            apply_rewinsor,
         )
         with ProcessPoolExecutor(max_workers=self.max_stack_workers) as exe:
             return exe.submit(_stack_worker, stack_args).result()


### PR DESCRIPTION
## Summary
- wire `apply_rewinsor` flag through the queue manager worker
- log start/finish of winsorized sigma clipping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a8b796a38832fb42651234eb1911d