### PR TITLE
Add current_preview for live stack

### DIFF
--- a/seestar/enhancement/drizzle_integration.py
+++ b/seestar/enhancement/drizzle_integration.py
@@ -487,6 +487,22 @@ class DrizzleIntegrator:
             self._wht_accum += wht
         self._n_images += 1
 
+    def current_preview(self) -> np.ndarray:
+        """Return a float32 normalised copy of the current stack.
+
+        Returns:
+            np.ndarray: Normalised drizzle accumulation.
+
+        Raises:
+            ValueError: If no images were added yet.
+        """
+        if self._sci_accum is None or self._wht_accum is None:
+            raise ValueError("No images added")
+
+        return (self._sci_accum / np.maximum(self._wht_accum, 1e-9)).astype(
+            np.float32
+        )
+
     def finalize(self) -> np.ndarray:
         """Return the stacked image after optional renormalization."""
         if self._sci_accum is None or self._wht_accum is None:

--- a/tests/test_drizzle_integration.py
+++ b/tests/test_drizzle_integration.py
@@ -1,0 +1,11 @@
+import numpy as np
+from seestar.enhancement.drizzle_integration import DrizzleIntegrator
+
+
+def test_current_preview():
+    integ = DrizzleIntegrator()
+    sci = np.ones((10, 10), np.float32)
+    wht = np.ones_like(sci) * 2
+    integ.add(sci, wht)
+    preview = integ.current_preview()
+    assert np.allclose(preview, 0.5)


### PR DESCRIPTION
## Summary
- add `current_preview()` to DrizzleIntegrator for normalized output
- test the new preview helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628756c1c8832fbe5ee4abe6a7e2b3