### PR TITLE
Filter flux kernel warnings

### DIFF
--- a/seestar/enhancement/drizzle_integration.py
+++ b/seestar/enhancement/drizzle_integration.py
@@ -10,6 +10,26 @@ import cv2
 from scipy.ndimage import gaussian_filter
 # ConvexHull n'est pas utilisé dans ce fichier
 
+_logger = logging.getLogger(__name__)
+_original_showwarning = warnings.showwarning
+
+# -------------------------------------------------------------
+# Filter the flood of "is not a flux-conserving kernel" warnings
+warnings.filterwarnings(
+    action="once",                                   # show only first
+    message=r".*is not a flux-conserving kernel\.$", # any kernel name
+    module=r"drizzle\.resample"
+)
+
+# Optional: log that first (now unique) occurrence via the project logger
+def _relay_first_warning(message, category, filename, lineno, file=None, line=None):
+    if ("is not a flux-conserving kernel" in str(message)
+            and category is RuntimeWarning):
+        _logger.warning(str(message))
+    _original_showwarning(message, category, filename, lineno, file, line)
+warnings.showwarning = _relay_first_warning
+# -------------------------------------------------------------
+
 logger = logging.getLogger(__name__)
 # ConvexHull n'est pas utilisé dans ce fichier
 

--- a/tests/test_warning_filter.py
+++ b/tests/test_warning_filter.py
@@ -1,0 +1,34 @@
+import importlib.util
+import io
+import sys
+import types
+import warnings
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "drizzle_integration", ROOT / "seestar" / "enhancement" / "drizzle_integration.py"
+)
+drizzle_integration = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = drizzle_integration
+spec.loader.exec_module(drizzle_integration)
+
+
+def test_kernel_warning_filtered():
+    spec.loader.exec_module(drizzle_integration)
+
+    fake_mod = types.ModuleType("drizzle.resample")
+    fake_mod.__dict__["__name__"] = "drizzle.resample"
+    exec(
+        "import warnings\n"
+        "def trigger():\n"
+        "    warnings.warn(\"Kernel 'whatever' is not a flux-conserving kernel.\", RuntimeWarning)",
+        fake_mod.__dict__,
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("default")
+        fake_mod.trigger()
+        fake_mod.trigger()
+
+    assert sum("flux-conserving kernel" in str(rec.message) for rec in w) == 1, "warning not filtered"


### PR DESCRIPTION
## Summary
- keep only the first `drizzle.resample` warning about non flux-conserving kernels
- test that the warning filter keeps only one occurrence

## Testing
- `pytest tests/test_warning_filter.py::test_kernel_warning_filtered -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862aa4dd694832f83289d0198e2081b