### PR TITLE
Silence drizzle kernel warnings

### DIFF
--- a/seestar/enhancement/drizzle_integration.py
+++ b/seestar/enhancement/drizzle_integration.py
@@ -10,25 +10,22 @@ import cv2
 from scipy.ndimage import gaussian_filter
 # ConvexHull n'est pas utilisé dans ce fichier
 
-_logger = logging.getLogger(__name__)
-_original_showwarning = warnings.showwarning
+import warnings
+import logging
 
-# -------------------------------------------------------------
-# Filter the flood of "is not a flux-conserving kernel" warnings
+_logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------
+#   Silence every "*is not a flux-conserving kernel*" warning that
+#   originates from drizzle.resample.*  We ignore all repetitions.
+# ------------------------------------------------------------------
 warnings.filterwarnings(
-    action="once",                                   # show only first
-    message=r".*is not a flux-conserving kernel\.$", # any kernel name
+    action="ignore",
+    message=r".*is not a flux-conserving kernel\.$",
     module=r"drizzle\.resample"
 )
-
-# Optional: log that first (now unique) occurrence via the project logger
-def _relay_first_warning(message, category, filename, lineno, file=None, line=None):
-    if ("is not a flux-conserving kernel" in str(message)
-            and category is RuntimeWarning):
-        _logger.warning(str(message))
-    _original_showwarning(message, category, filename, lineno, file, line)
-warnings.showwarning = _relay_first_warning
-# -------------------------------------------------------------
+_logger.debug("Flux-conserving kernel warnings are now filtered.")
+# ------------------------------------------------------------------
 
 logger = logging.getLogger(__name__)
 # ConvexHull n'est pas utilisé dans ce fichier


### PR DESCRIPTION
## Summary
- ignore flux-conserving kernel warnings from drizzle
- update tests to verify the warnings are muted
- add dedicated test for warning filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b2e366e8832fbf0407130199e58e