### PR TITLE
Add Astrometry solver settings

### DIFF
--- a/tests/test_solver_settings.py
+++ b/tests/test_solver_settings.py
@@ -1,0 +1,13 @@
+from zemosaic.solver_settings import SolverSettings
+import tempfile
+import json
+import pathlib
+
+
+def test_roundtrip():
+    tmp = pathlib.Path(tempfile.gettempdir()) / "solver.json"
+    s0 = SolverSettings(solver_choice="ASTROMETRY", api_key="ABC", timeout=42, downsample=3)
+    s0.save(tmp)
+    s1 = SolverSettings.load(tmp)
+    assert s0 == s1
+    tmp.unlink(missing_ok=True)

--- a/zemosaic/solver_settings.py
+++ b/zemosaic/solver_settings.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+import json
+from pathlib import Path
+
+
+@dataclass
+class SolverSettings:
+    """Persistent plate solver parameters."""
+
+    solver_choice: str = "ASTAP"
+    api_key: str = ""
+    timeout: int = 60
+    downsample: int = 2
+
+    def save(self, path: str | Path) -> None:
+        """Save settings to a JSON file."""
+        p = Path(path)
+        with p.open("w", encoding="utf-8") as fh:
+            json.dump(asdict(self), fh, indent=2)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "SolverSettings":
+        """Load settings from a JSON file."""
+        p = Path(path)
+        with p.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return cls(**data)


### PR DESCRIPTION
## Summary
- define `SolverSettings` dataclass with JSON save/load helpers
- expose solver options in `zemosaic_gui` with toggleable Astrometry.net fields
- test that `SolverSettings` roundtrips correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e00d5778832fa081c235968b4b64