### PR TITLE
Propagate RA/DEC in all final stacks

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9393,6 +9393,33 @@ class SeestarQueuedStacker:
             round(self.total_exposure_seconds, 2),
             "[s] Approx total exposure",
         )
+        # Propagate basic pointing information if absent
+        if "RA" not in final_header:
+            if "CRVAL1" in final_header:
+                final_header["RA"] = (
+                    float(final_header["CRVAL1"]),
+                    "[deg] Approx pointing RA from WCS",
+                )
+            elif getattr(self, "reference_header_for_wcs", None) is not None and "RA" in self.reference_header_for_wcs:
+                final_header["RA"] = (
+                    float(self.reference_header_for_wcs["RA"]),
+                    self.reference_header_for_wcs.comments["RA"]
+                    if "RA" in self.reference_header_for_wcs.comments
+                    else "[deg] Pointing RA from reference header",
+                )
+        if "DEC" not in final_header:
+            if "CRVAL2" in final_header:
+                final_header["DEC"] = (
+                    float(final_header["CRVAL2"]),
+                    "[deg] Approx pointing DEC from WCS",
+                )
+            elif getattr(self, "reference_header_for_wcs", None) is not None and "DEC" in self.reference_header_for_wcs:
+                final_header["DEC"] = (
+                    float(self.reference_header_for_wcs["DEC"]),
+                    self.reference_header_for_wcs.comments["DEC"]
+                    if "DEC" in self.reference_header_for_wcs.comments
+                    else "[deg] Pointing DEC from reference header",
+                )
         final_header["HISTORY"] = f"Final stack type: {current_operation_mode_log_fits}"
         if getattr(self, "output_filename", ""):
             base_name = self.output_filename.strip()

--- a/tests/test_save_final_stack.py
+++ b/tests/test_save_final_stack.py
@@ -367,3 +367,41 @@ def test_save_final_stack_classic_reproject_crop(tmp_path):
     assert np.array_equal(saved.astype(np.float32), data[1:3, 1:3])
     assert header["CRPIX1"] == 1.0
     assert header["CRPIX2"] == 1.0
+
+
+def test_save_final_stack_adds_radec(tmp_path):
+    obj = _make_obj(tmp_path, True)
+    obj.drizzle_active_session = True
+    obj.drizzle_mode = "Final"
+    obj.preserve_linear_output = True
+    obj.drizzle_output_wcs = make_wcs()
+
+    data = np.ones((2, 2), dtype=np.float32)
+    wht = np.ones_like(data, dtype=np.float32)
+
+    qm.SeestarQueuedStacker._save_final_stack(
+        obj,
+        drizzle_final_sci_data=data,
+        drizzle_final_wht_data=wht,
+        preserve_linear_output=True,
+    )
+
+    hdr = fits.getheader(obj.final_stacked_path)
+    assert "RA" in hdr and "DEC" in hdr
+    assert np.isclose(hdr["RA"], hdr["CRVAL1"])
+    assert np.isclose(hdr["DEC"], hdr["CRVAL2"])
+
+
+def test_save_final_stack_radec_from_reference_header(tmp_path):
+    obj = _make_obj(tmp_path, True)
+    obj.cumulative_sum_memmap = np.ones((2, 2, 3), dtype=np.float32)
+    obj.cumulative_wht_memmap = np.ones((2, 2), dtype=np.float32)
+    obj.reference_header_for_wcs = fits.Header()
+    obj.reference_header_for_wcs["RA"] = 12.34
+    obj.reference_header_for_wcs["DEC"] = 56.78
+
+    qm.SeestarQueuedStacker._save_final_stack(obj)
+
+    hdr = fits.getheader(obj.final_stacked_path)
+    assert np.isclose(hdr["RA"], 12.34)
+    assert np.isclose(hdr["DEC"], 56.78)


### PR DESCRIPTION
## Summary
- add RA/DEC fallback from reference header when WCS is absent
- test propagation of RA/DEC from reference header in classic mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b44efc2c832f9bf6b685eb7a7cdd