### PR TITLE
Enhance ASTAP solver preprocessing

### DIFF
--- a/tests/test_astap_prepare.py
+++ b/tests/test_astap_prepare.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from zemosaic.zemosaic_worker import _prepare_image_for_astap
+
+
+def test_mono_stays_2d():
+    arr = np.ones((5, 5), dtype=np.float32)
+    out = _prepare_image_for_astap(arr)
+    assert out.ndim == 2
+
+
+def test_hwc_to_chw():
+    arr = np.zeros((4, 6, 3), dtype=np.float32)
+    out = _prepare_image_for_astap(arr)
+    assert out.shape == (3, 4, 6)
+
+
+def test_chw_stays_chw():
+    arr = np.zeros((3, 4, 6), dtype=np.float32)
+    out = _prepare_image_for_astap(arr)
+    assert out.shape == (3, 4, 6)
+
+
+def test_force_lum():
+    arr = np.zeros((3, 4, 6), dtype=np.float32)
+    out = _prepare_image_for_astap(arr, force_lum=True)
+    assert out.ndim == 2 and out.shape == (4, 6)

--- a/tests/test_mosaic_worker.py
+++ b/tests/test_mosaic_worker.py
@@ -608,7 +608,7 @@ def test_use_sidecar_wcs(monkeypatch, tmp_path):
             data = np.ones((2, 2), dtype=np.float32)
             hdr = fits.Header()
             hdr["BITPIX"] = 16
-            return data, hdr
+            return data, hdr, {"axis_order_original": "HWC"}
 
         @staticmethod
         def debayer_image(img, pattern, progress_callback=None):

--- a/tests/test_solver_settings.py
+++ b/tests/test_solver_settings.py
@@ -6,7 +6,7 @@ import pathlib
 
 def test_roundtrip():
     tmp = pathlib.Path(tempfile.gettempdir()) / "solver.json"
-    s0 = SolverSettings(solver_choice="ASTROMETRY", api_key="ABC", timeout=42, downsample=3)
+    s0 = SolverSettings(solver_choice="ASTROMETRY", api_key="ABC", timeout=42, downsample=3, force_lum=True)
     s0.save(tmp)
     s1 = SolverSettings.load(tmp)
     assert s0 == s1

--- a/zemosaic/CHANGELOG.md
+++ b/zemosaic/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased
-- Added configurable `winsor_worker_limit` (CLI `--winsor-workers` / `-W` and GUI field)
-- Manual frame cap via `max_raw_per_master_tile` (CLI/GUI/config)
-- Fixed incremental assembly with reproject>=0.11
+### Fixed
+* Robust FITS writing for ASTAP CLI (colour order normalised)
+### Added
+* Solver option “Convert to Luminance” to force mono before plate-solve
+* Added configurable `winsor_worker_limit` (CLI `--winsor-workers` / `-W` and GUI field)
+* Manual frame cap via `max_raw_per_master_tile` (CLI/GUI/config)
+* Fixed incremental assembly with reproject>=0.11

--- a/zemosaic/locales/en.json
+++ b/zemosaic/locales/en.json
@@ -18,6 +18,7 @@
     "astap_downsample_note": "(0=auto, 1=2x2, 2=4x4...)",
     "astap_sensitivity_label": "ASTAP Sensitivity (-sens):",
     "astap_sensitivity_note": "(e.g., 100, higher = more sensitive)",
+    "force_lum_label": "Convert to Luminance (mono):",
     "panel_clustering_threshold_label": "Panel Clustering Threshold (deg):",
     "launch_button": "Start Hierarchical Mosaic",
     "log_frame_title": "Processing Logs",

--- a/zemosaic/locales/fr.json
+++ b/zemosaic/locales/fr.json
@@ -18,6 +18,7 @@
     "astap_downsample_note": "(0=auto, 1=2x2, 2=4x4...)",
     "astap_sensitivity_label": "Sensibilité ASTAP (-sens) :",
     "astap_sensitivity_note": "(ex: 100, plus grand = plus sensible)",
+    "force_lum_label": "Convertir en Luminance (mono) :",
     "panel_clustering_threshold_label": "Seuil Clustering Panneaux (deg) :",
     "launch_button": "Lancer la Mosaïque Hiérarchique",
     "log_frame_title": "Logs de Traitement",

--- a/zemosaic/solver_settings.py
+++ b/zemosaic/solver_settings.py
@@ -15,6 +15,7 @@ class SolverSettings:
     api_key: str = ""
     timeout: int = 60
     downsample: int = 2
+    force_lum: bool = False
 
     @staticmethod
     def default_path() -> Path:

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -147,6 +147,7 @@ class ZeMosaicGUI:
         self.astrometry_api_key_var = tk.StringVar(value=self.solver_settings.api_key)
         self.astrometry_timeout_var = tk.IntVar(value=self.solver_settings.timeout)
         self.astrometry_downsample_var = tk.IntVar(value=self.solver_settings.downsample)
+        self.force_lum_var = tk.BooleanVar(value=self.solver_settings.force_lum)
         
         self.is_processing = False
         self.worker_process = None
@@ -458,6 +459,9 @@ class ZeMosaicGUI:
         ttk.Label(params_frame, text="").grid(row=param_row_idx, column=2, padx=5, pady=3, sticky="w"); self.translatable_widgets["astap_sensitivity_note"] = params_frame.grid_slaves(row=param_row_idx,column=2)[0]; param_row_idx+=1
         ttk.Label(params_frame, text="").grid(row=param_row_idx, column=0, padx=5, pady=3, sticky="w"); self.translatable_widgets["panel_clustering_threshold_label"] = params_frame.grid_slaves(row=param_row_idx,column=0)[0]
         ttk.Spinbox(params_frame, from_=0.01, to=5.0, increment=0.01, textvariable=self.cluster_threshold_var, width=8, format="%.2f").grid(row=param_row_idx, column=1, padx=5, pady=3, sticky="w")
+        param_row_idx += 1
+        ttk.Label(params_frame, text=self._tr("force_lum_label", "Convert to Luminance (mono):")).grid(row=param_row_idx, column=0, padx=5, pady=3, sticky="w"); self.translatable_widgets["force_lum_label"] = params_frame.grid_slaves(row=param_row_idx,column=0)[0]
+        ttk.Checkbutton(params_frame, variable=self.force_lum_var).grid(row=param_row_idx, column=1, padx=5, pady=3, sticky="w")
 
         # --- Solver Selection Frame ---
         solver_frame = ttk.LabelFrame(self.scrollable_content_frame, text=self._tr("solver_frame_title", "Plate Solver"), padding="10")
@@ -1178,6 +1182,7 @@ class ZeMosaicGUI:
             self.solver_settings.api_key = self.astrometry_api_key_var.get().strip()
             self.solver_settings.timeout = self.astrometry_timeout_var.get()
             self.solver_settings.downsample = self.astrometry_downsample_var.get()
+            self.solver_settings.force_lum = bool(self.force_lum_var.get())
             try:
                 self.solver_settings.save_default()
             except Exception:

--- a/zemosaic/zemosaic_utils.py
+++ b/zemosaic/zemosaic_utils.py
@@ -136,9 +136,10 @@ def load_and_validate_fits(filepath,
 
     _log_util(f"Début chargement (V3 - BZERO/BSCALE affiné). Fichier: '{filename}'. NormalizeOutput01={normalize_to_float32}, FixNonFinite={attempt_fix_nonfinite}", "DEBUG")
 
-    data_raw_from_fits = None # Données telles que lues par fits.open
+    data_raw_from_fits = None  # Données telles que lues par fits.open
     header = None
     header_for_fallback = fits_module_for_utils.Header()
+    info = {}
 
     try:
         _log_util(f"Tentative fits_module_for_utils.open('{filepath}', do_not_scale_image_data=True)...", "DEBUG_DETAIL")
@@ -147,7 +148,7 @@ def load_and_validate_fits(filepath,
             _log_util(f"fits_module_for_utils.open OK. Nombre HDUs: {len(hdul) if hdul else 0}", "DEBUG_DETAIL")
             if not hdul:
                 _log_util(f"REJET: Fichier FITS vide ou corrompu (hdul est None/vide).", "WARN")
-                return None, header_for_fallback
+                return None, header_for_fallback, info
 
             hdu_img = None; img_hdu_idx = -1
             _log_util(f"Recherche HDU image...", "DEBUG_DETAIL")
@@ -171,7 +172,7 @@ def load_and_validate_fits(filepath,
                 _log_util(f"REJET: Aucune HDU image valide avec données.", "WARN")
                 if ASTROPY_AVAILABLE_IN_UTILS and len(hdul) > 0 and hasattr(hdul[0], 'header') and hdul[0].header:
                     header_for_fallback = hdul[0].header.copy()
-                return None, header_for_fallback
+                return None, header_for_fallback, info
 
             data_raw_from_fits = hdu_img.data # Peut être int16, uint16, float32, etc.
             header = hdu_img.header.copy(); header_for_fallback = header.copy()
@@ -201,17 +202,22 @@ def load_and_validate_fits(filepath,
 
             # --- Transposition si nécessaire ---
             data_transposed_f64 = data_scaled_f64
+            axis_orig = "HWC"
             if data_scaled_f64.ndim == 3:
                 if data_scaled_f64.shape[0] in [1, 3, 4] and data_scaled_f64.shape[1] > 4 and data_scaled_f64.shape[2] > 4:
                     _log_util(f"Shape 3D {data_scaled_f64.shape} type CxHxW. Transposition vers HxWxC...", "INFO_DETAIL")
                     data_transposed_f64 = np.moveaxis(data_scaled_f64, 0, -1)
+                    axis_orig = "CHW"
                     _log_util(f"  Shape après transposition: {data_transposed_f64.shape}", "DEBUG_DETAIL")
                 elif data_scaled_f64.shape[2] in [1, 3, 4] and data_scaled_f64.shape[0] > 4 and data_scaled_f64.shape[1] > 4:
                     _log_util(f"Shape 3D {data_scaled_f64.shape} déjà HxWxC.", "DEBUG_DETAIL")
+                    axis_orig = "HWC"
                 else:
-                    _log_util(f"REJET: Shape 3D non supportée ({data_scaled_f64.shape}).", "WARN"); return None, header
+                    _log_util(f"REJET: Shape 3D non supportée ({data_scaled_f64.shape}).", "WARN"); return None, header, info
             elif data_scaled_f64.ndim != 2:
-                _log_util(f"REJET: Shape {data_scaled_f64.ndim}D non supportée.", "WARN"); return None, header
+                _log_util(f"REJET: Shape {data_scaled_f64.ndim}D non supportée.", "WARN"); return None, header, info
+
+            info["axis_order_original"] = axis_orig
             
             _log_util(f"Après transposition (si 3D): Range [{np.min(data_transposed_f64):.1f}, {np.max(data_transposed_f64):.1f}], Dtype: {data_transposed_f64.dtype}", "DEBUG")
             
@@ -246,15 +252,18 @@ def load_and_validate_fits(filepath,
             else:
                 _log_util(f"Pas de normalisation 0-1 (ADU). Range final: [{np.nanmin(image_data_final_float32):.3g}, {np.nanmax(image_data_final_float32):.3g}]", "DEBUG_DETAIL")
 
-            _log_util(f"FIN chargement '{filename}'. Shape: {image_data_final_float32.shape}, Dtype: {image_data_final_float32.dtype}, "
-                      f"Range: [{np.nanmin(image_data_final_float32):.3g} - {np.nanmax(image_data_final_float32):.3g}], Mean: {np.nanmean(image_data_final_float32):.3g}", "INFO")
-            return image_data_final_float32, header
+            _log_util(
+                f"FIN chargement '{filename}'. Shape: {image_data_final_float32.shape}, Dtype: {image_data_final_float32.dtype}, "
+                f"Range: [{np.nanmin(image_data_final_float32):.3g} - {np.nanmax(image_data_final_float32):.3g}], Mean: {np.nanmean(image_data_final_float32):.3g}",
+                "INFO",
+            )
+            return image_data_final_float32, header, info
 
     except FileNotFoundError:
         _log_util(f"ERREUR CRITIQUE: Fichier non trouvé: '{filepath}'", "ERROR")
-        return None, header_for_fallback
+        return None, header_for_fallback, info
     except MemoryError as me:
-        _log_util(f"ERREUR CRITIQUE MÉMOIRE: {me}", "ERROR"); return None, header_for_fallback
+        _log_util(f"ERREUR CRITIQUE MÉMOIRE: {me}", "ERROR"); return None, header_for_fallback, info
     except Exception as e:
         _log_util(f"ERREUR INATTENDUE chargement/validation '{filename}': {type(e).__name__} - {e}", "ERROR")
         if progress_callback and hasattr(progress_callback.__self__ if hasattr(progress_callback, '__self__') else progress_callback, 'logger'):
@@ -264,7 +273,7 @@ def load_and_validate_fits(filepath,
              progress_callback(f"  [ZMU_LoadVal TRACEBACK] {traceback.format_exc(limit=3)}", None, "ERROR")
         else:
             traceback.print_exc(limit=3)
-        return None, header_for_fallback
+        return None, header_for_fallback, info
 
 
 
@@ -742,6 +751,54 @@ def stretch_percentile_rgb(img_hwc_adu, p_low=0.5, p_high=99.8,
         if progress_callback:
             progress_callback("stretch_utils_warn_unsupported_shape_for_stretch", lvl="WARN", shape=str(img_float.shape if hasattr(img_float, 'shape') else 'N/A'))
         return img_float.astype(np.float32) # Retourner en float32 au cas où
+
+
+def save_numpy_to_fits(image_data: np.ndarray, header, output_path: str, *, axis_order: str = "HWC", overwrite: bool = True) -> None:
+    """Write a NumPy array to FITS without any scaling.
+
+    Parameters
+    ----------
+    image_data : np.ndarray
+        Array to save. Can be 2-D or 3-D.
+    header : fits.Header or dict
+        Header to write with the data.
+    output_path : str
+        Destination FITS path.
+    axis_order : {"HWC", "CHW"}
+        Interpretation of 3-D arrays. ``HWC`` means channels last and the array
+        will be transposed to ``CxHxW`` for saving.
+    overwrite : bool
+        Overwrite existing file if True.
+    """
+
+    current_fits = fits_module_for_utils
+    final_header = current_fits.Header()
+    if header is not None:
+        try:
+            if hasattr(header, "to_header"):
+                final_header.update(header.to_header(relax=True))
+            else:
+                final_header.update(header)
+        except Exception:
+            pass
+
+    for key in ["SIMPLE", "BITPIX", "NAXIS", "EXTEND", "BSCALE", "BZERO"]:
+        if key in final_header:
+            try:
+                del final_header[key]
+            except KeyError:
+                pass
+
+    data_to_write = image_data
+    if image_data.ndim == 3:
+        ao = str(axis_order).upper()
+        if ao == "HWC":
+            data_to_write = np.moveaxis(image_data, -1, 0)
+    hdu = current_fits.PrimaryHDU(data=data_to_write, header=final_header)
+    hdul = current_fits.HDUList([hdu])
+    hdul.writeto(output_path, overwrite=overwrite)
+    if hasattr(hdul, "close"):
+        hdul.close()
 
 
 


### PR DESCRIPTION
## Summary
- preserve original axis order info when loading FITS
- provide `save_numpy_to_fits` helper
- normalize images before ASTAP solving and support luminance option
- expose `force_lum` in GUI and solver settings
- add tests for new normalization logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d8e9914c832f90beed3f889572f4