### PR TITLE
Fix master-tile progress updates

### DIFF
--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -1235,6 +1235,9 @@ class ZeMosaicGUI:
                 return
         
         # 4. DÉMARRAGE du traitement
+        # Remise à zéro du compteur master-tiles
+        if hasattr(self, "master_tile_count_var"):
+            self.master_tile_count_var.set("")
         self.is_processing = True
         self.launch_button.config(state=tk.DISABLED)
         self.log_text.config(state=tk.NORMAL); self.log_text.delete(1.0, tk.END); self.log_text.config(state=tk.DISABLED)
@@ -1341,6 +1344,9 @@ class ZeMosaicGUI:
             self._log_message("log_key_processing_finished", level="INFO")
             final_message = self._tr("msg_processing_completed")
             messagebox.showinfo(self._tr("dialog_title_completed"), final_message, parent=self.root)
+            # Nettoyage du compteur master-tiles affiché
+            if hasattr(self, "master_tile_count_var"):
+                self.master_tile_count_var.set("")
             output_dir_final = self.output_dir_var.get()
             if output_dir_final and os.path.isdir(output_dir_final):
                 if messagebox.askyesno(self._tr("q_open_output_folder_title"), self._tr("q_open_output_folder_msg", folder=output_dir_final), parent=self.root):

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -2178,9 +2178,6 @@ def run_hierarchical_mosaic(
         ): i_stk for i_stk, sg_info_list in enumerate(seestar_stack_groups)
     }
 
-    # Wait for all master-tile tasks to finish before processing results
-    executor_ph3.shutdown(wait=True)
-
     for future in as_completed(future_to_group_index):
 
             group_index_original = future_to_group_index[future]
@@ -2212,6 +2209,8 @@ def run_hierarchical_mosaic(
             total_eta_sec_ph3 = eta_phase3_sec + (100 - current_progress_in_run_percent_ph3) * time_per_percent_point_global_ph3
             update_gui_eta(total_eta_sec_ph3)
 
+    # Toutes les futures sont terminées → fermeture propre
+    executor_ph3.shutdown(wait=True)
 
     master_tiles_results_list = [master_tiles_results_list_temp[i] for i in sorted(master_tiles_results_list_temp.keys())]
     del master_tiles_results_list_temp; gc.collect()


### PR DESCRIPTION
## Summary
- update master tile worker loop so GUI gets progress sooner
- reset GUI master tile counter before starting processing
- clear counter when the worker finishes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ed0eb258832f8febbcdb2a594211