### PR TITLE
Remove auto_limit_memory_fraction parameter

### DIFF
--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -208,7 +208,6 @@ The configuration file exposes a few options to control memory consumption:
 
 - `auto_limit_frames_per_master_tile` – automatically split raw stacks based on available RAM.
 - `max_raw_per_master_tile` – manual cap on raw frames stacked per master tile (0 disables).
-- `auto_limit_memory_fraction` – fraction of free memory considered by the auto limiter.
 - `winsor_worker_limit` – maximum parallel workers during the Winsorized rejection step.
 
 6 ▸ Quick CLI example

--- a/zemosaic/zemosaic_config.json
+++ b/zemosaic/zemosaic_config.json
@@ -26,7 +26,6 @@
     "coadd_cleanup_memmap": true,
     "assembly_process_workers": 0,
     "auto_limit_frames_per_master_tile": true,
-    "auto_limit_memory_fraction": 0.1,
     "winsor_worker_limit": 8,
     "max_raw_per_master_tile": 20,
     "apply_master_tile_crop": true,

--- a/zemosaic/zemosaic_config.py
+++ b/zemosaic/zemosaic_config.py
@@ -33,7 +33,6 @@ DEFAULT_CONFIG = {
     "coadd_cleanup_memmap": True,
     "assembly_process_workers": 0,  # Worker count for final assembly (both methods)
     "auto_limit_frames_per_master_tile": True,
-    "auto_limit_memory_fraction": 0.1,
     "winsor_worker_limit": 4,
     "max_raw_per_master_tile": 0,
     # --- CLES POUR LE ROGNAGE DES MASTER TUILES ---

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -1287,7 +1287,6 @@ class ZeMosaicGUI:
             self.cleanup_memmap_var.get(),
             self.config.get("assembly_process_workers", 0),
             self.auto_limit_frames_var.get(),
-            self.config.get("auto_limit_memory_fraction", 0.1),
             self.winsor_workers_var.get(),
             self.max_raw_per_tile_var.get(),
             asdict(self.solver_settings)

--- a/zemosaic/zemosaic_worker.py
+++ b/zemosaic/zemosaic_worker.py
@@ -1873,7 +1873,6 @@ def run_hierarchical_mosaic(
     coadd_cleanup_memmap_config: bool,
     assembly_process_workers_config: int,
     auto_limit_frames_per_master_tile_config: bool,
-    auto_limit_memory_fraction_config: float,
     winsor_worker_limit_config: int,
     max_raw_per_master_tile_config: int,
     solver_settings: dict | None = None
@@ -2182,8 +2181,7 @@ def run_hierarchical_mosaic(
             limit = max(
                 1,
                 int(
-                    (available_bytes * auto_limit_memory_fraction_config)
-                    // (expected_workers * bytes_per_frame * 6)
+                    available_bytes // (expected_workers * bytes_per_frame * 6)
                 ),
             )
             if manual_limit > 0:


### PR DESCRIPTION
## Summary
- remove `auto_limit_memory_fraction` setting from config, GUI and worker
- adjust automatic frame limit logic to use all available RAM
- update README docs accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646a516740832f933a020f354dab47