### PR TITLE
Fix GUI freeze when autotuner changes threads

### DIFF
--- a/seestar/queuep/autotuner.py
+++ b/seestar/queuep/autotuner.py
@@ -99,7 +99,10 @@ class CpuIoAutoTuner:
         )
         try:
             self.stacker.thread_fraction = new_frac
-            self.stacker._configure_global_threads(new_frac)
+            if hasattr(self.stacker, "request_thread_fraction_update"):
+                self.stacker.request_thread_fraction_update(new_frac)
+            else:
+                self.stacker._configure_global_threads(new_frac)
             self.stacker.max_reproj_workers = max(1, int(os.cpu_count() * new_frac))
         except Exception as e:  # pragma: no cover - log only
             log.error("AutoTune : \u00e9chec de l'application : %s", e)


### PR DESCRIPTION
## Summary
- queue_manager: defer thread reconfiguration until safe
- autotuner: request thread updates instead of applying immediately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68668aaa9900832f8d27ddcf065fb37e