### PR TITLE
Fix GUI freeze in drizzle modes

### DIFF
--- a/seestar/enhancement/reproject_utils.py
+++ b/seestar/enhancement/reproject_utils.py
@@ -1,6 +1,9 @@
 try:
     from reproject.mosaicking import reproject_and_coadd as _reproject_and_coadd
-    from reproject import reproject_interp as _reproject_interp
+    from reproject import (
+        reproject_interp as _reproject_interp,
+        reproject_exact as _reproject_exact,
+    )
 except Exception:  # pragma: no cover - fallback when reproject missing
     def _missing(*_args, **_kwargs):
         raise ImportError(
@@ -13,4 +16,13 @@ except Exception:  # pragma: no cover - fallback when reproject missing
 reproject_and_coadd = _reproject_and_coadd
 reproject_interp = _reproject_interp
 
-__all__ = ["reproject_and_coadd", "reproject_interp"]
+from concurrent.futures import ProcessPoolExecutor
+
+
+def reproject_exact_mp(*args, **kwargs):
+    """Run ``reproject_exact`` in a separate process to avoid blocking the GUI."""
+
+    with ProcessPoolExecutor(max_workers=1) as ex:
+        return ex.submit(_reproject_exact, *args, **kwargs).result()
+
+__all__ = ["reproject_and_coadd", "reproject_interp", "reproject_exact_mp"]

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -80,11 +80,15 @@ from ..core.incremental_reprojection import (
     reproject_and_coadd_batch,
     reproject_and_combine,
 )
-from reproject import reproject_exact
+from reproject import reproject_exact as _reproject_exact
+try:
+    from seestar.enhancement.reproject_utils import reproject_exact_mp
+except Exception:
+    reproject_exact_mp = _reproject_exact
 import inspect
 
 
-_HAS_DRIZZLE_PARAM = "drizzle" in inspect.signature(reproject_exact).parameters
+_HAS_DRIZZLE_PARAM = "drizzle" in inspect.signature(_reproject_exact).parameters
 
 from ..core.normalization import (
     _normalize_images_linear_fit,
@@ -6562,13 +6566,13 @@ class SeestarQueuedStacker:
                     kwargs = {}
                     if _HAS_DRIZZLE_PARAM:
                         kwargs = {"drizzle": True, "pixfrac": self.drizzle_pixfrac, "kernel": self.drizzle_kernel}
-                    arr, _ = reproject_exact(
+                    arr, _ = reproject_exact_mp(
                         (weighted_input, wcs_for_pixmap),
                         self.drizzle_output_wcs,
                         shape_out=self.drizzle_output_shape_hw,
                         **kwargs,
                     )
-                    wht_reproj, _ = reproject_exact(
+                    wht_reproj, _ = reproject_exact_mp(
                         (weight_map_param_for_add, wcs_for_pixmap),
                         self.drizzle_output_wcs,
                         shape_out=self.drizzle_output_shape_hw,
@@ -8216,13 +8220,13 @@ class SeestarQueuedStacker:
                         kwargs = {}
                         if _HAS_DRIZZLE_PARAM:
                             kwargs = {"drizzle": True, "pixfrac": self.drizzle_pixfrac, "kernel": self.drizzle_kernel}
-                        arr, _ = reproject_exact(
+                        arr, _ = reproject_exact_mp(
                             (weighted_input, wcs_lot_intermediaire),
                             output_wcs_final_target,
                             shape_out=output_shape_final_target_hw,
                             **kwargs,
                         )
-                        wht_reproj, _ = reproject_exact(
+                        wht_reproj, _ = reproject_exact_mp(
                             (data_ch_wht_2d_lot, wcs_lot_intermediaire),
                             output_wcs_final_target,
                             shape_out=output_shape_final_target_hw,
@@ -11276,13 +11280,13 @@ class SeestarQueuedStacker:
                         kwargs = {}
                         if _HAS_DRIZZLE_PARAM:
                             kwargs = {"drizzle": True, "pixfrac": self.drizzle_pixfrac, "kernel": self.drizzle_kernel}
-                        arr, _ = reproject_exact(
+                        arr, _ = reproject_exact_mp(
                             (weighted_input, wcs_input_from_file_header),
                             output_wcs_target,
                             shape_out=output_shape_target_hw,
                             **kwargs,
                         )
-                        wht_r, _ = reproject_exact(
+                        wht_r, _ = reproject_exact_mp(
                             (effective_weight_map, wcs_input_from_file_header),
                             output_wcs_target,
                             shape_out=output_shape_target_hw,


### PR DESCRIPTION
## Summary
- add `reproject_exact_mp` wrapper using `ProcessPoolExecutor`
- fall back to normal `reproject_exact` when multiprocessing is unavailable
- use `reproject_exact_mp` for drizzle reprojection steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68668aaa9900832f8d27ddcf065fb37e