### PR TITLE
Prevent NaNs from reducing drizzle weights

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -6592,6 +6592,19 @@ class SeestarQueuedStacker:
                         shape_out=self.drizzle_output_shape_hw,
                         **kwargs,
                     )
+                    # ``reproject_exact`` can return tiny negative values
+                    # for very high resolution images. Clip to avoid
+                    # decreasing the accumulated weight sum.
+                    arr = np.clip(
+                        np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0),
+                        0.0,
+                        None,
+                    )
+                    wht_reproj = np.clip(
+                        np.nan_to_num(wht_reproj, nan=0.0, posinf=0.0, neginf=0.0),
+                        0.0,
+                        None,
+                    )
                     sci_arr += arr
                     wht_arr += wht_reproj
                     self.incremental_drizzle_sci_arrays[ch_idx] = sci_arr


### PR DESCRIPTION
## Summary
- sanitize `reproject_exact` outputs to remove NaNs before clipping to non-negative

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669304e134832f854f896030260834