### PR TITLE
Fix default threads configuration

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -630,10 +630,10 @@ class SeestarQueuedStacker:
         self,
         gpu: bool = False,
         io_profile: str = "ssd",
-        thread_fraction: float = 0.5,
+        thread_fraction: float = 0.75,
         batch_size: int | None = None,
         settings: SettingsManager | None = None,
-        autotune: bool = True,
+        autotune: bool = False,
         *args,
         **kwargs,
     ):


### PR DESCRIPTION
## Summary
- set default thread fraction to 75% of CPU cores
- disable autotune by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c86f14c0832fb790a040ea55c517