### PR TITLE
Fix fallback to spawn context

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -648,7 +648,12 @@ class SeestarQueuedStacker:
     ):
         """Launch incremental drizzle processing in a separate process."""
 
-        ctx = multiprocessing.get_context("fork")
+        # ``fork`` context is unavailable on some platforms (e.g. Windows).
+        # ``spawn`` is always supported, so fall back to it if ``fork`` cannot be used.
+        try:
+            ctx = multiprocessing.get_context("fork")
+        except ValueError:
+            ctx = multiprocessing.get_context("spawn")
         p = ctx.Process(
             target=self._process_incremental_drizzle_batch,
             args=(batch_temp_filepaths_list, current_batch_num, total_batches_est),


### PR DESCRIPTION
## Summary
- fix context selection for drizzle processing when `fork` is unavailable

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e56c7ea0832faf59e197bd709cae