### PR TITLE
Fix multiprocessing Tkinter pickle issue

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -550,6 +550,22 @@ class SeestarQueuedStacker:
 
     logger.debug("Lecture de la définition de la classe SeestarQueuedStacker...")
 
+    def __getstate__(self):
+        """Return picklable state for multiprocessing."""
+        state = self.__dict__.copy()
+        for attr in (
+            "progress_callback",
+            "preview_callback",
+            "queue",
+            "folders_lock",
+            "processing_thread",
+        ):
+            state[attr] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def _configure_global_threads(self, fraction: float) -> None:
         nthreads = max(1, math.floor(os.cpu_count() * fraction))
         for var in [


### PR DESCRIPTION
## Summary
- ensure `SeestarQueuedStacker` can be pickled for multiprocessing by stripping
  unpickleable callback and threading objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e76cecf8832fbbd664f3e867333b