### PR TITLE
Fix Tkinter pickle error in drizzle subprocess

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -559,6 +559,7 @@ class SeestarQueuedStacker:
             "queue",
             "folders_lock",
             "processing_thread",
+            "gui",
 
             "autotuner",
             "drizzle_processes",


### PR DESCRIPTION
## Summary
- ensure QueueManager's GUI attribute isn't serialized when spawning drizzle process

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ee57207c832fad1bb73802930f10