### PR TITLE
Fix Tkinter pickle error in drizzle subprocess

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -559,12 +559,29 @@ class SeestarQueuedStacker:
             "queue",
             "folders_lock",
             "processing_thread",
+            "gui",
+
+            "aligner",
+            "local_aligner_instance",
+            "astrometry_solver",
+            "chroma_balancer",
 
             "autotuner",
             "drizzle_processes",
 
         ):
             state[attr] = None
+
+        # Remove any tkinter objects that may have been stored dynamically
+        try:
+            import tkinter
+        except Exception:
+            tkinter = None
+        if tkinter is not None:
+            for k, v in list(state.items()):
+                if v is not None and type(v).__module__.startswith("tkinter"):
+                    state[k] = None
+
         return state
 
     def __setstate__(self, state):


### PR DESCRIPTION
## Summary
- ensure QueueManager's GUI attribute isn't serialized when spawning drizzle process
- filter tkinter objects when creating SeestarQueuedStacker state for pickling
- remove aligner and solver references when pickling to avoid tkinter callbacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866ee57207c832fad1bb73802930f10