### PR TITLE
Fix Windows spawn ProcessPoolExecutor

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -786,7 +786,7 @@ class SeestarQueuedStacker:
         parent_is_daemon = multiprocessing.current_process().daemon
         if platform.system() in {"Windows", "Darwin"}:
             ctx = multiprocessing.get_context("spawn")
-            Executor = ctx.ProcessPoolExecutor
+            Executor = partial(ProcessPoolExecutor, mp_context=ctx)
         else:
             Executor = ProcessPoolExecutor if not parent_is_daemon else ThreadPoolExecutor
 


### PR DESCRIPTION
## Summary
- fix drizzle executor creation with multiprocessing spawn context
- ensure tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c9d014dc832f9e5551854b003e40