### PR TITLE
Implement iterative winsorized sigma clip

### DIFF
--- a/seestar/core/stack_methods.py
+++ b/seestar/core/stack_methods.py
@@ -2,6 +2,15 @@
 
 import numpy as np
 import logging
+from typing import Optional, Sequence, Tuple
+
+try:  # optional acceleration
+    import bottleneck as bn  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    bn = None
+
+NANMEAN = bn.nanmean if bn else np.nanmean
+NANSTD = bn.nanstd if bn else np.nanstd
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +51,7 @@ def _stack_kappa_sigma(images, weights=None, sigma_low=3.0, sigma_high=3.0):
         sum_d = np.nansum(arr_clip * w, axis=0)
         result = np.divide(sum_d, sum_w, out=np.zeros_like(sum_d), where=sum_w > 1e-6)
     else:
-        result = np.nanmean(arr_clip, axis=0)
+        result = NANMEAN(arr_clip, axis=0)
     rejected_pct = 100.0 * (mask.size - np.count_nonzero(mask)) / float(mask.size)
     return result.astype(np.float32), rejected_pct
 
@@ -63,55 +72,145 @@ def _stack_linear_fit_clip(images, weights=None, sigma=3.0):
         sum_d = np.nansum(arr_clip * w, axis=0)
         result = np.divide(sum_d, sum_w, out=np.zeros_like(sum_d), where=sum_w > 1e-6)
     else:
-        result = np.nanmean(arr_clip, axis=0)
+        result = NANMEAN(arr_clip, axis=0)
     rejected_pct = 100.0 * (mask.size - np.count_nonzero(mask)) / float(mask.size)
     return result.astype(np.float32), rejected_pct
 
 
-def _stack_winsorized_sigma(
-    images,
-    weights,
-    kappa=3.0,
-    winsor_limits=(0.05, 0.05),
-    apply_rewinsor=True,
-):
-    """Winsorized sigma clip stacking used by the queue manager."""
+def _stack_winsorized_sigma_iter(
+    images: Sequence[np.ndarray],
+    weights: Optional[np.ndarray],
+    kappa: float = 3.0,
+    winsor_limits: Tuple[float, float] = (0.05, 0.05),
+    apply_rewinsor: bool = True,
+    max_iters: int = 5,
+    kappa_decay: float = 0.9,
+    max_mem_bytes: int = 2_000_000_000,
+) -> Tuple[np.ndarray, float]:
+    """Iterative Winsorized sigma clipping.
+
+    Parameters
+    ----------
+    images : Sequence[np.ndarray]
+        List or array of images ``(N, H, W)`` or ``(N, H, W, 3)``.
+    weights : Optional[np.ndarray]
+        Optional weight array of shape ``(N,)``.
+    kappa : float, optional
+        Sigma clipping threshold. Defaults to ``3.0``.
+    winsor_limits : Tuple[float, float], optional
+        Fractional limits for Winsorization ``(low, high)``.
+    apply_rewinsor : bool, optional
+        Replace rejected pixels with their winsorized value if ``True``,
+        otherwise with ``NaN``.
+    max_iters : int, optional
+        Maximum number of iterations. Defaults to ``5``.
+    kappa_decay : float, optional
+        Multiplicative decay for ``kappa`` at each iteration.
+    max_mem_bytes : int, optional
+        Abort if stacking would exceed this memory usage.
+
+    Returns
+    -------
+    Tuple[np.ndarray, float]
+        Stacked image and rejection percentage.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from seestar.core.stack_methods import _stack_winsorized_sigma
+    >>> rng = np.random.default_rng(0)
+    >>> data = rng.normal(0, 1, size=(5, 4, 4)).astype(np.float32)
+    >>> data[0, 0, 0] = 50
+    >>> out, pct = _stack_winsorized_sigma(data, None)
+    >>> out.shape
+    (4, 4)
+    """
+
     logger.debug(
         "Winsorized sigma clip start: kappa=%s limits=%s apply_rewinsor=%s",
         kappa,
         winsor_limits,
         apply_rewinsor,
     )
-    from scipy.stats.mstats import winsorize
-    from astropy.stats import sigma_clipped_stats
 
-    arr = np.stack([im for im in images], axis=0).astype(np.float32)
-    arr_w = winsorize(arr, limits=winsor_limits, axis=0)
-    try:
-        _, med, std = sigma_clipped_stats(arr_w, sigma=3.0, axis=0, maxiters=5)
-    except TypeError:
-        _, med, std = sigma_clipped_stats(
-            arr_w, sigma_lower=3.0, sigma_upper=3.0, axis=0, maxiters=5
+    from scipy.stats.mstats import winsorize
+
+    shape = images[0].shape
+    exp_bytes = len(images) * np.prod(shape) * 4
+    if exp_bytes > max_mem_bytes:
+        raise MemoryError("Stack exceeds max_mem_bytes")
+
+    arr = np.stack([im.astype(np.float32, copy=False) for im in images], axis=0)
+    mask = np.ones_like(arr, dtype=bool)
+    kappa_iter = float(kappa)
+
+    for itr in range(max_iters):
+        arr_masked = np.ma.array(arr, mask=~mask)
+        arr_w = winsorize(arr_masked, limits=winsor_limits, axis=0)
+        arr_w_data = np.asarray(arr_w.filled(np.nan), dtype=np.float32)
+        mu_w = NANMEAN(arr_w_data, axis=0)
+        sigma_w = NANSTD(arr_w_data, axis=0, ddof=1)
+        low = mu_w - kappa_iter * sigma_w
+        high = mu_w + kappa_iter * sigma_w
+        new_mask = mask & (arr >= low) & (arr <= high)
+        n_rej = np.count_nonzero(mask) - np.count_nonzero(new_mask)
+        logger.debug(
+            "WinsorSig iter=%d : rej=%d (%.2f%%)",
+            itr + 1,
+            n_rej,
+            100.0 * n_rej / mask.size,
         )
-    low = med - kappa * std
-    high = med + kappa * std
-    mask = (arr >= low) & (arr <= high)
+        mask = new_mask
+        if n_rej == 0:
+            break
+        if kappa_decay < 1.0:
+            kappa_iter = kappa * (kappa_decay ** (itr + 1))
+
+    arr_masked = np.ma.array(arr, mask=~mask)
+    arr_w_final = winsorize(arr_masked, limits=winsor_limits, axis=0)
+    arr_w_final = np.asarray(arr_w_final.filled(np.nan), dtype=np.float32)
+
+    arr_nan = np.where(mask, arr, np.nan)
     if apply_rewinsor:
-        arr_clip = np.where(mask, arr, arr_w)
+        arr_final = np.where(mask, arr, arr_w_final)
     else:
-        arr_clip = np.where(mask, arr, np.nan)
+        arr_final = arr_nan
+
     if weights is not None:
-        w = np.asarray(weights)[:, None, None]
+        w = np.asarray(weights, dtype=np.float32)[:, None, None]
         if arr.ndim == 4:
             w = w[..., None]
         sum_w = np.nansum(w * mask, axis=0)
-        sum_d = np.nansum(arr_clip * w, axis=0)
-        result = np.divide(sum_d, sum_w, out=np.zeros_like(sum_d), where=sum_w > 1e-6)
+        sum_d = np.nansum(arr_nan * w, axis=0)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            result = np.divide(
+                sum_d,
+                sum_w,
+                out=np.zeros_like(sum_d),
+                where=sum_w > 1e-6,
+            )
     else:
-        result = np.nanmean(arr_clip, axis=0)
+        result = NANMEAN(arr_final, axis=0)
+
     rejected_pct = 100.0 * (mask.size - np.count_nonzero(mask)) / float(mask.size)
-    logger.debug("Winsorized sigma clip done: %.2f%% of pixels rejected",
-        rejected_pct,
-    )
+    logger.debug("WinsorSig done : total rej=%.2f%%", rejected_pct)
+
     return result.astype(np.float32), rejected_pct
+
+
+def _stack_winsorized_sigma(
+    images: Sequence[np.ndarray],
+    weights: Optional[np.ndarray],
+    kappa: float = 3.0,
+    winsor_limits: Tuple[float, float] = (0.05, 0.05),
+    apply_rewinsor: bool = True,
+) -> Tuple[np.ndarray, float]:
+    """Compatibility wrapper for iterative Winsorized sigma clipping."""
+    return _stack_winsorized_sigma_iter(
+        images,
+        weights,
+        kappa=kappa,
+        winsor_limits=winsor_limits,
+        apply_rewinsor=apply_rewinsor,
+    )
 

--- a/tests/test_winsorized_sigma.py
+++ b/tests/test_winsorized_sigma.py
@@ -1,0 +1,47 @@
+import importlib.util
+import numpy as np
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "stack_methods", ROOT / "seestar" / "core" / "stack_methods.py"
+)
+stack_methods = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(stack_methods)
+_stack_winsorized_sigma = stack_methods._stack_winsorized_sigma
+
+
+def _generate_data(color=False):
+    rng = np.random.default_rng(0)
+    N, H, W = 20, 32, 32
+    if color:
+        base = rng.normal(100.0, 5.0, size=(N, H, W, 3)).astype(np.float32)
+        clean = base.copy()
+        mask = rng.random((N, H, W, 1)) < 0.05
+        base[mask.repeat(3, axis=-1)] = rng.uniform(150, 200, size=np.count_nonzero(mask) * 3)
+    else:
+        base = rng.normal(100.0, 5.0, size=(N, H, W)).astype(np.float32)
+        clean = base.copy()
+        mask = rng.random((N, H, W)) < 0.05
+        base[mask] = rng.uniform(150, 200, size=mask.sum())
+    return base, clean
+
+
+def test_winsorized_sigma_monochrome():
+    data, clean = _generate_data(False)
+    result, pct = _stack_winsorized_sigma(data, None, kappa=3.0, winsor_limits=(0.05, 0.05))
+    assert 3 < pct < 10
+    mean_true = np.mean(clean)
+    assert np.isclose(np.mean(result), mean_true, rtol=0.02)
+
+
+def test_winsorized_sigma_color_with_weights():
+    data, clean = _generate_data(True)
+    rng = np.random.default_rng(1)
+    weights = rng.random(data.shape[0]).astype(np.float32)
+    result, pct = _stack_winsorized_sigma(data, weights, kappa=3.0, winsor_limits=(0.05, 0.05))
+    assert 3 < pct < 10
+    w = weights[:, None, None, None]
+    expected = np.sum(clean * w, axis=0) / np.sum(w, axis=0)
+    mean_true = np.mean(expected)
+    assert np.isclose(np.mean(result), mean_true, rtol=0.02)


### PR DESCRIPTION
## Summary
- reimplement `_stack_winsorized_sigma` as iterative algorithm with optional memory guard
- add bottleneck-based acceleration and improved broadcasting
- provide unit tests for rejection rate and mean accuracy

## Testing
- `pytest -q tests/test_winsorized_sigma.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68681b883d60832fa133d7b544f60f88