### PR TITLE
Fix histogram handles resetting after each batch

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -3715,6 +3715,14 @@ class SeestarStackerGUI:
                     print(
                         "    [RefreshPreview] Returned from histogram_widget.update_histogram."
                     )
+                    try:
+                        bp_ui = self.preview_black_point.get()
+                        wp_ui = self.preview_white_point.get()
+                    except tk.TclError:
+                        bp_ui = None
+                        wp_ui = None
+                    if bp_ui is not None and wp_ui is not None:
+                        self.histogram_widget.set_range(bp_ui, wp_ui)
             else:
                 print(
                     "  [RefreshPreview] Recalcul de l'histogramme ignoré (recalculate_histogram=False)."
@@ -4232,6 +4240,14 @@ class SeestarStackerGUI:
                     print(
                         "    [RefreshPreview] Returned from histogram_widget.update_histogram."
                     )
+                    try:
+                        bp_ui = self.preview_black_point.get()
+                        wp_ui = self.preview_white_point.get()
+                    except tk.TclError:
+                        bp_ui = None
+                        wp_ui = None
+                    if bp_ui is not None and wp_ui is not None:
+                        self.histogram_widget.set_range(bp_ui, wp_ui)
             else:
                 print(
                     "  [RefreshPreview] Recalcul de l'histogramme ignoré (recalculate_histogram=False)."


### PR DESCRIPTION
## Summary
- persist BP/WP lines after histogram updates by re-applying the current slider values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c6dae1b8832f8ef3ae8ecfe910e2