### PR TITLE
Enable Reproject & Coadd with reference WCS

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -10789,6 +10789,7 @@ class SeestarQueuedStacker:
                 self.drizzle_active_session
                 or self.is_mosaic_run
                 or self.reproject_between_batches
+                or self.reproject_coadd_final
             ):
                 logger.debug(
                     "DEBUG QM (start_processing): Plate-solving de la référence principale requis..."


### PR DESCRIPTION
## Summary
- trigger plate-solving of the reference frame when `reproject_coadd_final` is selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868ecfb46a4832faae8e8bd0bb98290