### PR TITLE
Fix final reproject-coadd option

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -7010,6 +7010,7 @@ class SeestarStackerGUI:
             "save_as_float32": self.settings.save_final_as_float32,
             "preserve_linear_output": self.settings.preserve_linear_output,
             "reproject_between_batches": self.settings.reproject_between_batches,
+            "reproject_coadd_final": self.settings.reproject_coadd_final,
         }
         import inspect
 

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -10508,6 +10508,7 @@ class SeestarQueuedStacker:
         save_as_float32=False,
         preserve_linear_output=False,
         reproject_between_batches=False,
+        reproject_coadd_final=False,
     ):
         logger.debug(
             f"!!!!!!!!!! VALEUR BRUTE ARGUMENT astap_search_radius REÇU : {astap_search_radius} !!!!!!!!!!"
@@ -10518,8 +10519,11 @@ class SeestarQueuedStacker:
 
         """
         Démarre le thread de traitement principal avec la configuration spécifiée.
-        MODIFIED: Ajout arguments save_as_float32 et reproject_between_batches.
-        Version: V_StartProcessing_SaveDtypeOption_1
+        
+        MODIFIED:
+            - Ajout des arguments ``save_as_float32``, ``reproject_between_batches``
+              et ``reproject_coadd_final``.
+        Version: V_StartProcessing_SaveDtypeOption_2
         """
 
         logger.debug(
@@ -10738,6 +10742,11 @@ class SeestarQueuedStacker:
         # intermediate batches are not solved again.
         if self.reproject_between_batches and not self.freeze_reference_wcs:
             self.freeze_reference_wcs = True
+
+        self.reproject_coadd_final = bool(reproject_coadd_final)
+        logger.debug(
+            f"    [OutputFormat] self.reproject_coadd_final (attribut d'instance) mis à : {self.reproject_coadd_final} (depuis argument {reproject_coadd_final})"
+        )
 
         # Disable solving of intermediate batches when reprojection is active
         # and the reference WCS should remain fixed.


### PR DESCRIPTION
## Summary
- ensure `start_processing` takes a `reproject_coadd_final` flag
- propagate this option from the GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686942e88b68832fb611ac8105bddcd8