### PR TITLE
Disable auto stretch on incremental preview updates

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4100,7 +4100,7 @@ class SeestarStackerGUI:
             if self.drizzle_mode_var.get() == "Incremental":
                 self.current_preview_data = preview_display
                 self.current_preview_hist_data = preview_hist
-                self.apply_auto_stretch()
+                self.refresh_preview()
                 return
             # Non-drizzle modes keep existing behaviour
             self.refresh_preview()

--- a/tests/test_auto_stretch.py
+++ b/tests/test_auto_stretch.py
@@ -74,4 +74,5 @@ def test_dynamic_autostretch_triggers():
         2,
     )
 
-    assert gui.preview_black_point.get() == 0.1
+    assert gui.preview_black_point.get() == 0.25
+    assert gui.preview_white_point.get() == 0.75


### PR DESCRIPTION
## Summary
- keep user-selected stretch in incremental drizzle mode
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686946a50bb8832f973c8bdc1eaeb4ac