### PR TITLE
Add master tile crop option

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -593,6 +593,10 @@ class SeestarStackerGUI:
 
         self.final_edge_crop_percent_var = tk.DoubleVar(value=2.0)
 
+        # Option to crop master tiles before stacking
+        self.apply_master_tile_crop_var = tk.BooleanVar(value=False)
+        self.master_tile_crop_percent_var = tk.DoubleVar(value=18.0)
+
         # --- nouveaux toggles Expert ---
         self.apply_bn_var = tk.BooleanVar(value=True)
         self.apply_cb_var = tk.BooleanVar(value=True)
@@ -1059,6 +1063,30 @@ class SeestarStackerGUI:
             width=6,
             state="readonly",
         ).grid(row=0, column=1, sticky=tk.W, padx=(5, 0))
+
+        crop_frame = ttk.Frame(tab_stacking)
+        crop_frame.pack(fill=tk.X, padx=5, pady=(0, 5))
+        self.crop_master_check = ttk.Checkbutton(
+            crop_frame,
+            text="Crop master tiles",
+            variable=self.apply_master_tile_crop_var,
+            command=self._update_master_tile_crop_state,
+        )
+        self.crop_master_check.grid(row=0, column=0, sticky=tk.W)
+        ttk.Label(crop_frame, text="Crop % per side").grid(
+            row=0, column=1, sticky=tk.W, padx=(10, 2)
+        )
+        self.master_tile_crop_spinbox = ttk.Spinbox(
+            crop_frame,
+            from_=0.0,
+            to=25.0,
+            increment=0.5,
+            textvariable=self.master_tile_crop_percent_var,
+            width=6,
+            format="%.1f",
+        )
+        self.master_tile_crop_spinbox.grid(row=0, column=2, sticky=tk.W)
+        self._update_master_tile_crop_state()
         self.options_frame = ttk.LabelFrame(tab_stacking, text="Stacking Options")
         self.options_frame.pack(fill=tk.X, pady=5, padx=5)
 
@@ -2296,6 +2324,7 @@ class SeestarStackerGUI:
         self._update_bn_options_state()
         self._update_cb_options_state()
         self._update_crop_options_state()
+        self._update_master_tile_crop_state()
         print(
             "DEBUG (GUI create_layout V_SaveAsFloat32_1): Fin création layout et appels _update_..._state."
         )  # Version Log
@@ -2474,6 +2503,13 @@ class SeestarStackerGUI:
                 w.config(state=new_state)
             except tk.TclError:
                 pass
+
+    def _update_master_tile_crop_state(self, *args):
+        new_state = tk.NORMAL if self.apply_master_tile_crop_var.get() else tk.DISABLED
+        try:
+            self.master_tile_crop_spinbox.config(state=new_state)
+        except tk.TclError:
+            pass
 
     ###############################################################################
 
@@ -3929,6 +3965,11 @@ class SeestarStackerGUI:
             if hasattr(self, "apply_cb_var"):
                 self.apply_cb_var.set(default_settings.apply_cb)
 
+            if hasattr(self, "apply_master_tile_crop_var"):
+                self.apply_master_tile_crop_var.set(default_settings.apply_master_tile_crop)
+            if hasattr(self, "master_tile_crop_percent_var"):
+                self.master_tile_crop_percent_var.set(default_settings.master_tile_crop_percent)
+
             # Rognage Final
             if hasattr(self, "final_edge_crop_percent_var"):
                 self.final_edge_crop_percent_var.set(
@@ -3988,6 +4029,8 @@ class SeestarStackerGUI:
                 self._update_cb_options_state()
             if hasattr(self, "_update_crop_options_state"):
                 self._update_crop_options_state()
+            if hasattr(self, "_update_master_tile_crop_state"):
+                self._update_master_tile_crop_state()
             # Si d'autres groupes d'options dans l'onglet expert ont des états dépendants,
             # appelez leurs méthodes _update_..._state() ici aussi.
 
@@ -6985,6 +7028,8 @@ class SeestarStackerGUI:
             "cb_blur_radius": self.settings.cb_blur_radius,
             "cb_min_b_factor": self.settings.cb_min_b_factor,
             "cb_max_b_factor": self.settings.cb_max_b_factor,
+            "apply_master_tile_crop": self.settings.apply_master_tile_crop,
+            "master_tile_crop_percent": self.settings.master_tile_crop_percent,
             "final_edge_crop_percent": self.settings.final_edge_crop_percent,
             "apply_photutils_bn": self.settings.apply_photutils_bn,
             "photutils_bn_box_size": self.settings.photutils_bn_box_size,

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -412,6 +412,20 @@ class SettingsManager:
                     value=default_values_from_code.get("final_edge_crop_percent", 2.0)
                 ),
             ).get()
+            self.apply_master_tile_crop = getattr(
+                gui_instance,
+                "apply_master_tile_crop_var",
+                tk.BooleanVar(
+                    value=default_values_from_code.get("apply_master_tile_crop", False)
+                ),
+            ).get()
+            self.master_tile_crop_percent = getattr(
+                gui_instance,
+                "master_tile_crop_percent_var",
+                tk.DoubleVar(
+                    value=default_values_from_code.get("master_tile_crop_percent", 18.0)
+                ),
+            ).get()
             self.apply_final_crop = getattr(
                 gui_instance,
                 "apply_final_crop_var",
@@ -968,6 +982,12 @@ class SettingsManager:
             getattr(gui_instance, "apply_cb_var", tk.BooleanVar()).set(
                 self.apply_cb
             )
+            getattr(gui_instance, "apply_master_tile_crop_var", tk.BooleanVar()).set(
+                self.apply_master_tile_crop
+            )
+            getattr(gui_instance, "master_tile_crop_percent_var", tk.DoubleVar()).set(
+                self.master_tile_crop_percent
+            )
             getattr(gui_instance, "final_edge_crop_percent_var", tk.DoubleVar()).set(
                 self.final_edge_crop_percent
             )
@@ -1246,6 +1266,8 @@ class SettingsManager:
         defaults_dict["cb_min_b_factor"] = 0.4
         defaults_dict["cb_max_b_factor"] = 1.5
         defaults_dict["apply_cb"] = True
+        defaults_dict["apply_master_tile_crop"] = False
+        defaults_dict["master_tile_crop_percent"] = 18.0
         defaults_dict["final_edge_crop_percent"] = 2.0
         defaults_dict["apply_final_crop"] = True
         defaults_dict["apply_photutils_bn"] = False
@@ -1901,6 +1923,24 @@ class SettingsManager:
             self.apply_cb = bool(
                 getattr(self, "apply_cb", defaults_fallback["apply_cb"])
             )
+            self.apply_master_tile_crop = bool(
+                getattr(
+                    self,
+                    "apply_master_tile_crop",
+                    defaults_fallback["apply_master_tile_crop"],
+                )
+            )
+            self.master_tile_crop_percent = float(
+                np.clip(
+                    getattr(
+                        self,
+                        "master_tile_crop_percent",
+                        defaults_fallback["master_tile_crop_percent"],
+                    ),
+                    0.0,
+                    25.0,
+                )
+            )
             self.final_edge_crop_percent = float(
                 np.clip(
                     getattr(
@@ -2431,6 +2471,8 @@ class SettingsManager:
             "cb_min_b_factor": float(self.cb_min_b_factor),
             "cb_max_b_factor": float(self.cb_max_b_factor),
             "apply_cb": bool(self.apply_cb),
+            "apply_master_tile_crop": bool(self.apply_master_tile_crop),
+            "master_tile_crop_percent": float(self.master_tile_crop_percent),
             "final_edge_crop_percent": float(self.final_edge_crop_percent),
             "apply_final_crop": bool(self.apply_final_crop),
             "apply_photutils_bn": bool(self.apply_photutils_bn),


### PR DESCRIPTION
## Summary
- add option to crop master tiles in GUI and settings
- pass crop settings to queue manager and apply crop when saving batches
- support new parameters in queue manager start_processing
- test cropping behaviour for classic batches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686984d05054832f9dcae71820e12d8c