### PR TITLE
Fix cropping option for ZeMosaic reproject

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9325,7 +9325,9 @@ class SeestarQueuedStacker:
                 progress_callback=lambda m, p=None: self.update_progress(f"   {m}"),
                 n_channels=3,
                 match_bg=True,
-                apply_crop=False,
+                apply_crop=getattr(self, "apply_master_tile_crop", False),
+                crop_percent=getattr(self, "master_tile_crop_percent_decimal", 0.0)
+                * 100.0,
                 use_gpu=False,
             )
         except Exception as e:


### PR DESCRIPTION
## Summary
- forward crop settings when using `assemble_final_mosaic_with_reproject_coadd`

## Testing
- `pytest tests/test_queue_manager_reproject.py -vv`
- `pytest tests/test_queue_manager_reproject.py::test_reproject_classic_batches_uses_fixed -vv`


------
https://chatgpt.com/codex/tasks/task_e_68699c2f8614832f9863d8187f21c475