### PR TITLE
Fix ZeMosaic callback parameter handling

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9322,7 +9322,9 @@ class SeestarQueuedStacker:
                 master_tile_fits_with_wcs_list=master_tiles,
                 final_output_wcs=out_wcs,
                 final_output_shape_hw=out_shape,
-                progress_callback=lambda m, p=None: self.update_progress(f"   {m}"),
+                progress_callback=lambda m, p=None, lvl=None, **kw: self.update_progress(
+                    f"   {m}", p
+                ),
                 n_channels=3,
                 match_bg=True,
                 apply_crop=getattr(self, "apply_master_tile_crop", False),


### PR DESCRIPTION
## Summary
- accept optional level/kwargs in ZeMosaic progress callback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a462615c832fa6bd01621b7d5a8b