### PR TITLE
Fix reproject&coadd output saving

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9453,7 +9453,10 @@ class SeestarQueuedStacker:
             and drizzle_final_sci_data is None
         )
         is_classic_reproject_mode = (
-            self.reproject_between_batches
+            (
+                self.reproject_between_batches
+                or getattr(self, "reproject_coadd_final", False)
+            )
             and drizzle_final_sci_data is not None
             and drizzle_final_wht_data is not None
         )


### PR DESCRIPTION
## Summary
- ensure the final stack uses the reprojected image when `reproject_coadd_final` is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ab4cd410832fbb78592418e27cf0