### PR TITLE
Fix shape mismatch in reproject mode

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9202,6 +9202,23 @@ class SeestarQueuedStacker:
             )
             return
 
+        # Validate output shape against the WCS to avoid orientation issues
+        if out_wcs.pixel_shape is not None:
+            expected_hw = (out_wcs.pixel_shape[1], out_wcs.pixel_shape[0])
+            if out_shape != expected_hw:
+                if out_shape == expected_hw[::-1]:
+                    self.update_progress(
+                        "⚠️ Final grid shape transposée, correction automatique.",
+                        "WARN",
+                    )
+                    out_shape = expected_hw
+                else:
+                    self.update_progress(
+                        "❌ Shape finale incohérente avec WCS.pixel_shape.",
+                        "ERROR",
+                    )
+                    return
+
         final_channels = []
         final_cov = None
         for ch in range(3):
@@ -9308,6 +9325,22 @@ class SeestarQueuedStacker:
             )
             if out_wcs is None:
                 return False
+
+        if out_wcs.pixel_shape is not None:
+            expected_hw = (out_wcs.pixel_shape[1], out_wcs.pixel_shape[0])
+            if out_shape != expected_hw:
+                if out_shape == expected_hw[::-1]:
+                    self.update_progress(
+                        "⚠️ Final grid shape transposée, correction automatique.",
+                        "WARN",
+                    )
+                    out_shape = expected_hw
+                else:
+                    self.update_progress(
+                        "❌ Shape finale incohérente avec WCS.pixel_shape.",
+                        "ERROR",
+                    )
+                    return False
 
         try:
             data_hwc, cov_hw = zemosaic_worker.assemble_final_mosaic_with_reproject_coadd(

--- a/zemosaic/locales/en.json
+++ b/zemosaic/locales/en.json
@@ -312,5 +312,8 @@
 
     "assemble_error_invalid_final_shape_inc": "Incremental assembly ERROR: invalid final output shape {shape}.",
     "assemble_warn_swapped_final_shape_inc": "Incremental assembly WARNING: provided dimensions {provided} were swapped, expected {expected}. Automatically corrected.",
-    "assemble_error_mismatch_final_shape_inc": "Incremental assembly ERROR: provided dimensions {provided} do not match mosaic grid {expected}."
+    "assemble_error_mismatch_final_shape_inc": "Incremental assembly ERROR: provided dimensions {provided} do not match mosaic grid {expected}.",
+    "assemble_error_invalid_final_shape_reproj_coadd": "Reproject & Coadd ERROR: invalid final output shape {shape}.",
+    "assemble_warn_swapped_final_shape_reproj_coadd": "Reproject & Coadd WARNING: provided dimensions {provided} were swapped, expected {expected}. Automatically corrected.",
+    "assemble_error_mismatch_final_shape_reproj_coadd": "Reproject & Coadd ERROR: provided dimensions {provided} do not match mosaic grid {expected}."
 }

--- a/zemosaic/locales/fr.json
+++ b/zemosaic/locales/fr.json
@@ -308,5 +308,8 @@
 
     "assemble_error_invalid_final_shape_inc": "ERREUR assemblage incrémental : dimensions finales invalides {shape}.",
     "assemble_warn_swapped_final_shape_inc": "AVERTISSEMENT assemblage incrémental : dimensions fournies {provided} inversées, attendu {expected}. Correction automatique.",
-    "assemble_error_mismatch_final_shape_inc": "ERREUR assemblage incrémental : dimensions fournies {provided} incompatibles avec la grille {expected}."
+    "assemble_error_mismatch_final_shape_inc": "ERREUR assemblage incrémental : dimensions fournies {provided} incompatibles avec la grille {expected}.",
+    "assemble_error_invalid_final_shape_reproj_coadd": "ERREUR Reproject & Coadd : dimensions finales invalides {shape}.",
+    "assemble_warn_swapped_final_shape_reproj_coadd": "AVERTISSEMENT Reproject & Coadd : dimensions fournies {provided} inversées, attendu {expected}. Correction automatique.",
+    "assemble_error_mismatch_final_shape_reproj_coadd": "ERREUR Reproject & Coadd : dimensions fournies {provided} incompatibles avec la grille {expected}."
 }


### PR DESCRIPTION
## Summary
- validate output shape versus `pixel_shape` before running reproject & coadd

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b49bd7a0832fb1435245880af434