### PR TITLE
Check local solver before reproject

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6770,6 +6770,37 @@ class SeestarStackerGUI:
             "DEBUG (GUI start_processing): Phase 2 - Vérification avertissement OK (ou non applicable)."
         )
 
+        # --- Additional check: reproject modes require a configured local solver ---
+        if (
+            self.reproject_between_batches_var.get()
+            or getattr(self, "reproject_coadd_var", tk.BooleanVar()).get()
+        ):
+            use_solver = self.use_third_party_solver_var.get()
+            solver_pref = getattr(self.settings, "local_solver_preference", "none")
+            astap_path = getattr(self.settings, "astap_path", "").strip()
+            ansvr_path = getattr(self.settings, "local_ansvr_path", "").strip()
+            astrometry_dir = getattr(self.settings, "astrometry_solve_field_dir", "").strip()
+            api_key = getattr(self.settings, "astrometry_api_key", "").strip()
+
+            solver_configured = False
+            if solver_pref == "astap":
+                solver_configured = bool(astap_path)
+            elif solver_pref == "ansvr":
+                solver_configured = bool(ansvr_path)
+            elif solver_pref == "astrometry":
+                solver_configured = bool(astrometry_dir or api_key)
+            else:
+                solver_configured = any([astap_path, ansvr_path, astrometry_dir, api_key])
+
+            if not (use_solver and solver_configured):
+                messagebox.showerror(
+                    self.tr("error"),
+                    self.tr("reproject_solver_required_error")
+                )
+                if hasattr(self, "start_button") and self.start_button.winfo_exists():
+                    self.start_button.config(state=tk.NORMAL)
+                return
+
         # --- 3. Initialisation de l'état de traitement du GUI ---
         print(
             "DEBUG (GUI start_processing): Phase 3 - Initialisation état de traitement GUI..."

--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -355,6 +355,7 @@ EN_TRANSLATIONS = {
     "ok_button": "OK",
     "cancel_button": "Cancel",
     "tooltip_enable_batch_reproject": "Requires a working solver (ASTAP, Astrometry.net, or Ansvr)",
+    "reproject_solver_required_error": "Reproject & Coadd requires an active local astrometric solver (ASTAP or local Astrometry.net). Please enable it in the solver settings.",
     # final log popup
     "Post-Processing Applied": "Post-Processing Applied",
     "Photutils 2D Background": "Photutils 2D Background",

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -374,6 +374,7 @@ FR_TRANSLATIONS = {
     "ok_button": "OK",
     "cancel_button": "Annuler",
     "tooltip_enable_batch_reproject": "Nécessite un solveur fonctionnel (ASTAP, Astrometry.net ou Ansvr)",
+    "reproject_solver_required_error": "Le mode \u00ab Reproject & Coadd \u00bb n\u00e9cessite un solveur astrom\u00e9trique local actif (ASTAP ou Astrometry.net local). Veuillez l'activer dans les param\u00e8tres du solveur.",
     # --- Tooltips pour Feathering ---
     "tooltip_apply_feathering": "Feathering : Si activé, adoucit l'image empilée en se basant sur une version floutée de la carte de poids totale. Peut aider à réduire les transitions brusques ou les artefacts aux bords des données combinées ou là où les poids changent abruptement. Agit avant la soustraction de fond Photutils.",
     "tooltip_feather_blur_px": "Rayon de Flou Feathering (px) : Contrôle l'étendue du flou appliqué à la carte de poids pour le feathering. Des valeurs plus grandes donnent des transitions plus douces et graduelles. Plage typique : 64-512. Défaut : 256.",


### PR DESCRIPTION
## Summary
- add missing translations for solver requirement error
- prevent starting a stack with reproject modes when no local solver is configured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac0e2e114832fa2d442ebfa62c772