### PR TITLE
Fix cropping for reproject mosaic output

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9806,7 +9806,6 @@ class SeestarQueuedStacker:
 
         if final_wht_map_for_postproc is not None and (
             is_classic_reproject_mode
-            or is_reproject_mosaic_mode
             or is_true_incremental_drizzle_from_objects
             or is_drizzle_final_mode_with_data
         ):


### PR DESCRIPTION
## Summary
- stop cropping the reproject & coadd mosaic output using the weight map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'photutils')*

------
https://chatgpt.com/codex/tasks/task_e_686b6ce1456c832f92c3393c5f8a8649