### PR TITLE
Enable ASTAP .app usage on macOS

### DIFF
--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -5,6 +5,7 @@ import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import os  # Pour les opérations sur les chemins
 from zemosaic import zemosaic_config
+import sys
 from .ui_utils import ToolTip
 
 class LocalSolverSettingsWindow(tk.Toplevel):
@@ -483,10 +484,14 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         elif os.path.exists(current_path):
              initial_dir = os.path.dirname(current_path)
 
-        file_types = [(self.tr("executable_files", default="Executable Files"), "*.*")] 
-        if os.name == 'nt': 
-            file_types = [(self.tr("astap_executable_win", default="ASTAP Executable"), "*.exe"), 
-                          (self.tr("all_files", default="All Files"), "*.*")]
+        file_types = [(self.tr("executable_files", default="Executable Files"), "*.*")]
+        if os.name == 'nt':
+            file_types = [
+                (self.tr("astap_executable_win", default="ASTAP Executable"), "*.exe"),
+                (self.tr("all_files", default="All Files"), "*.*"),
+            ]
+        elif sys.platform == 'darwin':
+            file_types.insert(0, (self.tr("astap_app_mac", default="ASTAP Application"), "*.app"))
         
         filepath = filedialog.askopenfilename(
             title=self.tr("select_astap_executable_title", default="Select ASTAP Executable"),

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -29,6 +29,7 @@ from astropy.io import fits
 from PIL import Image, ImageTk
 
 from zemosaic import zemosaic_config
+from seestar.alignment.astrometry_solver import _resolve_astap_executable
 
 from .ui_utils import ToolTip
 
@@ -5340,7 +5341,9 @@ class SeestarStackerGUI:
             env = os.environ.copy()
             if self.settings.use_third_party_solver:
                 if getattr(self.settings, "astap_path", ""):
-                    env["ZEMOSAIC_ASTAP_PATH"] = str(self.settings.astap_path)
+                    env["ZEMOSAIC_ASTAP_PATH"] = str(
+                        _resolve_astap_executable(self.settings.astap_path)
+                    )
                 if getattr(self.settings, "astap_data_dir", ""):
                     env["ZEMOSAIC_ASTAP_DATA_DIR"] = str(self.settings.astap_data_dir)
                 if getattr(self.settings, "local_ansvr_path", ""):

--- a/seestar/gui/mosaic_gui.py
+++ b/seestar/gui/mosaic_gui.py
@@ -1,8 +1,9 @@
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 # import traceback # Décommentez si besoin pour le debug
-import numpy as np 
+import numpy as np
 import os   # Pour les chemins de fichiers
+import sys
 # VALID_DRIZZLE_KERNELS est déjà défini dans votre fichier, je le garde.
 VALID_DRIZZLE_KERNELS = ['square', 'turbo', 'point', 'gaussian', 'lanczos2', 'lanczos3'] 
 
@@ -554,6 +555,8 @@ class MosaicSettingsWindow(tk.Toplevel):
                 (self.parent_gui.tr("astap_executable_win", default="ASTAP Executable"), "*.exe"),
                 (self.parent_gui.tr("all_files", default="All Files"), "*.*"),
             ]
+        elif sys.platform == 'darwin':
+            file_types.insert(0, (self.parent_gui.tr("astap_app_mac", default="ASTAP Application"), "*.app"))
 
         filepath = filedialog.askopenfilename(
             title=self.parent_gui.tr("select_astap_executable_title", default="Select ASTAP Executable"),

--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -328,6 +328,7 @@ EN_TRANSLATIONS = {
     "local_solver_info_text": "Leave paths empty if the solver is not used or is in system PATH.\nConsult solver documentation for specific path requirements.",
     "executable_files": "Executable Files",
     "astap_executable_win": "ASTAP Executable",  # Specific for Windows .exe
+    "astap_app_mac": "ASTAP Application",
     "all_files": "All Files",
     "select_astap_executable_title": "Select ASTAP Executable",
     "select_astap_data_dir_title": "Select ASTAP Star Index Data Directory",

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -347,6 +347,7 @@ FR_TRANSLATIONS = {
     "local_solver_info_text": "Laissez les chemins vides si le solveur n'est pas utilisé ou est dans le PATH système.\nConsultez la documentation du solveur pour les chemins spécifiques requis.",
     "executable_files": "Fichiers Exécutables",
     "astap_executable_win": "Exécutable ASTAP",  # Spécifique pour .exe Windows
+    "astap_app_mac": "Application ASTAP",
     "all_files": "Tous les Fichiers",
     "select_astap_executable_title": "Sélectionner l'Exécutable ASTAP",
     "select_astap_data_dir_title": "Sélectionner le Répertoire des Données d'Index Stellaires ASTAP",

--- a/seestar/scripts/run_mosaic.py
+++ b/seestar/scripts/run_mosaic.py
@@ -8,6 +8,7 @@ via command-line arguments.
 """
 import argparse
 import logging
+from seestar.alignment.astrometry_solver import _resolve_astap_executable
 
 from zemosaic import zemosaic_config, zemosaic_worker
 
@@ -49,7 +50,7 @@ def main() -> None:
     config = zemosaic_config.load_config()
 
     solver_settings = {
-        "astap_path": args.astap_path,
+        "astap_path": _resolve_astap_executable(args.astap_path) if args.astap_path else None,
         "astap_data_dir": args.astap_data_dir,
         "astap_search_radius": args.search_radius,
         "local_ansvr_path": args.local_ansvr_path,


### PR DESCRIPTION
## Summary
- add `_resolve_astap_executable` helper to support `.app` bundles
- use executable resolver when launching the solver and when calling ZeMosaic
- allow `.app` selection in solver setting dialogs
- expose new translation key `astap_app_mac`
- update CLI mosaic runner to resolve `.app` paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc7a4da84832fb81b3a1bdca7e57c