### PR TITLE
Enable macOS ASTAP path handling

### DIFF
--- a/tests/test_zemosaic_config.py
+++ b/tests/test_zemosaic_config.py
@@ -33,3 +33,14 @@ def test_config_round_trip_preserves_new_keys(tmp_path, monkeypatch):
     assert loaded["solver_method"] == "ansvr"
     assert loaded["astrometry_local_path"] == "/tmp/ansvr"
     assert loaded["astrometry_api_key"] == "XYZ123"
+
+
+def test_resolve_astap_app(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin", raising=False)
+    app_path = "/Applications/ASTAP.app"
+    internal = "/Applications/ASTAP.app/Contents/MacOS/astap"
+    monkeypatch.setattr(zemosaic_config.os.path, "isdir", lambda p: p == app_path)
+    monkeypatch.setattr(zemosaic_config.os.path, "isfile", lambda p: p == internal)
+
+    resolved = zemosaic_config.resolve_astap_executable_path(app_path)
+    assert resolved == internal

--- a/zemosaic/README.md
+++ b/zemosaic/README.md
@@ -34,8 +34,10 @@ It was born out of a need from an astrophotography Discord community called the 
 
 ### Mandatory:
 
-- Python ≥ 3.9  
+- Python ≥ 3.9
 - [ASTAP](https://www.hnsky.org/astap.htm) installed with G17/H17 star catalogs
+- Works on Linux, Windows and **macOS**. On macOS select `ASTAP.app` and
+  ZeMosaic will automatically resolve the internal executable.
 
 ### Recommended Python packages:
 

--- a/zemosaic/zemosaic_gui.py
+++ b/zemosaic/zemosaic_gui.py
@@ -1053,9 +1053,17 @@ class ZeMosaicGUI:
                                        self._tr("astap_exe_not_set_warning", "ASTAP executable path is not set."),
                                        parent=self.root)
         else:
-            filetypes_loc = [(self._tr("executable_files", "Executable Files"), "*.exe"), (self._tr("all_files", "All Files"), "*.*")] if os.name == 'nt' else [(self._tr("all_files", "All Files"), "*")]
+            if sys.platform == 'darwin':
+                filetypes_loc = [(self._tr("application_files", "Application Bundles"), "*.app"), (self._tr("all_files", "All Files"), "*")]
+            elif os.name == 'nt':
+                filetypes_loc = [(self._tr("executable_files", "Executable Files"), "*.exe"), (self._tr("all_files", "All Files"), "*.*")]
+            else:
+                filetypes_loc = [(self._tr("all_files", "All Files"), "*")]
             exe_path = filedialog.askopenfilename(title=self._tr("select_astap_exe_no_save_title", "Select ASTAP Executable (Not Saved)"), filetypes=filetypes_loc)
-            if exe_path: self.astap_exe_path_var.set(exe_path)
+            if exe_path:
+                if ZEMOSAIC_CONFIG_AVAILABLE and zemosaic_config:
+                    exe_path = zemosaic_config.resolve_astap_executable_path(exe_path)
+                self.astap_exe_path_var.set(exe_path)
 
     def _browse_and_save_astap_data_dir(self):
         title = self._tr("select_astap_data_dir_title", "Select ASTAP Data Directory")


### PR DESCRIPTION
## Summary
- add `resolve_astap_executable_path` helper to convert `.app` bundles
- allow GUI and config helpers to work with ASTAP.app on macOS
- document cross‑platform support in README
- test ASTAP.app resolution

## Testing
- `pytest -q tests/test_zemosaic_config.py::test_resolve_astap_app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcac81c48832f8c523334b8f346bd