### PR TITLE
Fix WCS header for classic reprojection output

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9244,6 +9244,9 @@ class SeestarQueuedStacker:
                 final_cov = cov.astype(np.float32)
 
         final_img_hwc = np.stack(final_channels, axis=-1)
+        # Provide an accurate WCS header for the final stack
+        self.current_stack_header = fits.Header()
+        self.current_stack_header.update(out_wcs.to_header(relax=True))
         self._save_final_stack(
             "_classic_reproject",
             drizzle_final_sci_data=final_img_hwc,


### PR DESCRIPTION
## Summary
- ensure the final classic reprojection stack has a valid WCS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'photutils')*

------
https://chatgpt.com/codex/tasks/task_e_686c428bd60c832fbd274403b45a253f