### PR TITLE
Fix WCS pixel shape for reprojected batches

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9155,8 +9155,14 @@ class SeestarQueuedStacker:
                     data_cxhxw = hdul[0].data.astype(np.float32)
                     hdr = hdul[0].header
                 batch_wcs = WCS(hdr, naxis=2)
-                h, w = data_cxhxw.shape[-2:]
+                h = int(hdr.get("NAXIS2", data_cxhxw.shape[-2]))
+                w = int(hdr.get("NAXIS1", data_cxhxw.shape[-1]))
                 batch_wcs.pixel_shape = (w, h)
+                try:
+                    batch_wcs.wcs.naxis1 = w
+                    batch_wcs.wcs.naxis2 = h
+                except Exception:
+                    pass
             except Exception:
                 continue
 


### PR DESCRIPTION
## Summary
- ensure `naxis1` and `naxis2` are set on batch WCS objects before calling `reproject_and_coadd`

## Testing
- `pytest tests/test_queue_manager_reproject.py::test_reproject_classic_batches_uses_fixed -q` *(fails: ModuleNotFoundError: No module named 'photutils')*

------
https://chatgpt.com/codex/tasks/task_e_686c592d7650832f8ff1bcfb8f7e68ab