### PR TITLE
Fix WCS pixel shape for reprojected batches

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9007,7 +9007,12 @@ class SeestarQueuedStacker:
         np.nan_to_num(final_wht, copy=False)
 
 
-        if self.solve_batches:
+        solve_needed = (
+            self.solve_batches
+            or self.reproject_between_batches
+            or self.reproject_coadd_final
+        )
+        if solve_needed:
             # Always attempt to solve the intermediate batch with ASTAP so that a
             # valid WCS is present on each stacked batch file. This is required for
             # the optional inter-batch reprojection step (performed on stacked batches).
@@ -9155,8 +9160,14 @@ class SeestarQueuedStacker:
                     data_cxhxw = hdul[0].data.astype(np.float32)
                     hdr = hdul[0].header
                 batch_wcs = WCS(hdr, naxis=2)
-                h, w = data_cxhxw.shape[-2:]
+                h = int(hdr.get("NAXIS2", data_cxhxw.shape[-2]))
+                w = int(hdr.get("NAXIS1", data_cxhxw.shape[-1]))
                 batch_wcs.pixel_shape = (w, h)
+                try:
+                    batch_wcs.wcs.naxis1 = w
+                    batch_wcs.wcs.naxis2 = h
+                except Exception:
+                    pass
             except Exception:
                 continue
 
@@ -10907,8 +10918,7 @@ class SeestarQueuedStacker:
         self.reproject_between_batches = bool(reproject_between_batches)
         # When inter-batch reprojection is requested we typically want to keep
         # the reference WCS stable. If the caller did not explicitly set
-        # ``freeze_reference_wcs`` beforehand, enable it automatically so that
-        # intermediate batches are not solved again.
+        # ``freeze_reference_wcs`` beforehand, enable it automatically.
         if self.reproject_between_batches and not self.freeze_reference_wcs:
             self.freeze_reference_wcs = True
 
@@ -10917,11 +10927,9 @@ class SeestarQueuedStacker:
             f"    [OutputFormat] self.reproject_coadd_final (attribut d'instance) mis à : {self.reproject_coadd_final} (depuis argument {reproject_coadd_final})"
         )
 
-        # Disable solving of intermediate batches when reprojection is active
-        # and the reference WCS should remain fixed.
-        self.solve_batches = not (
-            self.reproject_between_batches and self.freeze_reference_wcs
-        )
+        # Always solve intermediate batches when reprojection is requested so
+        # that a valid WCS is available for each stacked batch.
+        self.solve_batches = True
 
         # Determine if we should keep the original input frame size when
         # reprojection between batches is enabled (to avoid changing the


### PR DESCRIPTION
## Summary
- ensure `naxis1` and `naxis2` are set on batch WCS objects before calling `reproject_and_coadd`
- always solve intermediate batches when reprojection modes are enabled

## Testing
- `pytest tests/test_queue_manager_reproject.py::test_reproject_classic_batches_uses_fixed -q` *(fails: ModuleNotFoundError: No module named 'photutils')*

------
https://chatgpt.com/codex/tasks/task_e_686c592d7650832f8ff1bcfb8f7e68ab