### PR TITLE
Fix orientation when using reproject and coadd

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9211,7 +9211,16 @@ class SeestarQueuedStacker:
             except Exception:
                 coverage = np.ones((h, w), dtype=np.float32)
 
-            img_hwc = np.moveaxis(data_cxhxw, 0, -1)
+            if (
+                data_cxhxw.ndim == 3
+                and data_cxhxw.shape[0] in (1, 3)
+                and data_cxhxw.shape[-1] != data_cxhxw.shape[0]
+            ):
+                img_hwc = np.moveaxis(data_cxhxw, 0, -1)
+            else:
+                img_hwc = data_cxhxw
+                if img_hwc.ndim == 2:
+                    img_hwc = img_hwc[..., np.newaxis]
             wcs_for_grid.append(batch_wcs)
             headers_for_grid.append(hdr)
             for ch in range(img_hwc.shape[2]):


### PR DESCRIPTION
## Summary
- avoid always moving first axis when loading stacked batches
- handle already HWC stacked tiles properly for final reproject-and-coadd

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c78e486d0832fad234c2dda0f1d37