### PR TITLE
Fix misalignment in classic reproject combine

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -94,7 +94,6 @@ from ..core.background import (
 from ..core.drizzle_utils import drizzle_finalize
 from ..core.incremental_reprojection import (
     reproject_and_coadd_batch,
-    reproject_and_combine,
 )
 from ..core.normalization import (
     _normalize_images_linear_fit,
@@ -9173,11 +9172,10 @@ class SeestarQueuedStacker:
     def _reproject_classic_batches(self, batch_files):
         """Reproject saved classic batches to a common grid using reproject_and_coadd."""
 
-        from seestar.enhancement.reproject_utils import reproject_interp
         from seestar.core.incremental_reprojection import (
-            initialize_master,
-            reproject_and_combine,
+            reproject_and_coadd_batch,
         )
+        from seestar.enhancement.reproject_utils import reproject_interp
 
         wcs_for_grid = []
         headers_for_grid = []
@@ -9272,65 +9270,39 @@ class SeestarQueuedStacker:
                     )
                     return
 
-        master_sum = None
-        master_cov = None
-        for i, (sci_path, wht_paths) in enumerate(batch_files):
+        images = []
+        headers = []
+        for sci_path, _wht_paths in batch_files:
             try:
                 with fits.open(sci_path, memmap=False) as hdul:
                     data_cxhxw = hdul[0].data.astype(np.float32)
                     hdr = hdul[0].header
-                batch_wcs = WCS(hdr, naxis=2)
-                h = int(hdr.get("NAXIS2", data_cxhxw.shape[-2]))
-                w = int(hdr.get("NAXIS1", data_cxhxw.shape[-1]))
-                batch_wcs.pixel_shape = (w, h)
-                batch_wcs.array_shape = (h, w)
+                if (
+                    data_cxhxw.ndim == 3
+                    and data_cxhxw.shape[0] in (1, 3)
+                    and data_cxhxw.shape[-1] != data_cxhxw.shape[0]
+                ):
+                    img_hwc = np.moveaxis(data_cxhxw, 0, -1)
+                else:
+                    img_hwc = data_cxhxw
+                    if img_hwc.ndim == 2:
+                        img_hwc = img_hwc[..., np.newaxis]
+                images.append(img_hwc)
+                headers.append(hdr)
             except Exception:
                 continue
 
-            try:
-                coverage = fits.getdata(wht_paths[0]).astype(np.float32)
-                np.nan_to_num(coverage, copy=False)
-                hh, ww = coverage.shape
-                coverage *= make_radial_weight_map(hh, ww)
-            except Exception:
-                coverage = np.ones((h, w), dtype=np.float32)
-
-            if (
-                data_cxhxw.ndim == 3
-                and data_cxhxw.shape[0] in (1, 3)
-                and data_cxhxw.shape[-1] != data_cxhxw.shape[0]
-            ):
-                img_hwc = np.moveaxis(data_cxhxw, 0, -1)
-            else:
-                img_hwc = data_cxhxw
-                if img_hwc.ndim == 2:
-                    img_hwc = img_hwc[..., np.newaxis]
-
-            if master_sum is None:
-                master_sum, master_cov = initialize_master(
-                    img_hwc,
-                    coverage,
-                    batch_wcs,
-                    out_wcs,
-                    use_gpu=False,
-                )
-            else:
-                master_sum, master_cov = reproject_and_combine(
-                    master_sum,
-                    master_cov,
-                    img_hwc,
-                    coverage,
-                    batch_wcs,
-                    out_wcs,
-                    use_gpu=False,
-                )
-
-        if master_sum is None or master_cov is None:
+        if not images:
             return
 
-        master_cov = np.maximum(master_cov, 1e-6)
-        final_img_hwc = master_sum / master_cov[..., None]
-        final_cov = master_cov
+        final_img_hwc, final_cov = reproject_and_coadd_batch(
+            images,
+            headers,
+            out_wcs,
+            out_shape,
+        )
+        if final_img_hwc is None or final_cov is None:
+            return
         self._save_final_stack(
             "_classic_reproject",
             drizzle_final_sci_data=final_img_hwc,


### PR DESCRIPTION
## Summary
- align final "reproject and coadd" combine using batch reprojection
- update QueueManager to call `reproject_and_coadd_batch`

## Testing
- `pytest -q tests/test_queue_manager_reproject.py::test_reproject_classic_batches_uses_fixed -q`
- `pytest -q tests/test_mosaic_worker.py::test_resolve_after_crop -q`
- `pytest -q tests/test_reproject_utils.py -q`
- `pytest -q tests/test_incremental_reprojection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686ccf5f5340832f866fcd0bf75374e5