### PR TITLE
Fix WCS alignment for classic reproject

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9122,6 +9122,18 @@ class SeestarQueuedStacker:
         fits.PrimaryHDU(data=data_cxhxw, header=header).writeto(
             sci_fits, overwrite=True, output_verify="ignore"
         )
+
+        # After cropping, resolve again with ASTAP to ensure the WCS
+        # matches the final saved tile. This avoids misalignment when
+        # assembling with reproject_and_coadd.
+        if self.solve_batches:
+            try:
+                if self._run_astap_and_update_header(sci_fits):
+                    solved_hdr = fits.getheader(sci_fits, memmap=False)
+                    header.update(solved_hdr)
+            except Exception:
+                pass
+
         for ch_i in range(final_stacked.shape[2]):
             wht_path = os.path.join(
                 out_dir, f"classic_batch_{batch_idx:03d}_wht_{ch_i}.fits"

--- a/tests/test_queue_manager_reproject.py
+++ b/tests/test_queue_manager_reproject.py
@@ -633,6 +633,57 @@ def test_save_classic_batch_crop(monkeypatch, tmp_path):
     assert header["CRPIX2"] == 4.0
 
 
+def test_save_classic_batch_crop_resolves(monkeypatch, tmp_path):
+    sys.path.insert(0, str(ROOT))
+    import importlib
+    import types
+
+    if "seestar.gui" not in sys.modules:
+        seestar_pkg = types.ModuleType("seestar")
+        seestar_pkg.__path__ = [str(ROOT / "seestar")]
+        gui_pkg = types.ModuleType("seestar.gui")
+        gui_pkg.__path__ = []
+        settings_mod = types.ModuleType("seestar.gui.settings")
+        settings_mod.SettingsManager = object
+        hist_mod = types.ModuleType("seestar.gui.histogram_widget")
+        hist_mod.HistogramWidget = object
+        gui_pkg.settings = settings_mod
+        gui_pkg.histogram_widget = hist_mod
+        seestar_pkg.gui = gui_pkg
+        sys.modules["seestar"] = seestar_pkg
+        sys.modules["seestar.gui"] = gui_pkg
+        sys.modules["seestar.gui.settings"] = settings_mod
+        sys.modules["seestar.gui.histogram_widget"] = hist_mod
+
+    qm = importlib.import_module("seestar.queuep.queue_manager")
+
+    obj = qm.SeestarQueuedStacker()
+    obj.update_progress = lambda *a, **k: None
+    obj.apply_master_tile_crop = True
+    obj.master_tile_crop_percent_decimal = 0.1
+    obj.output_folder = str(tmp_path)
+    obj.solve_batches = True
+
+    calls = {"n": 0}
+
+    def fake_run_astap(self, path):
+        calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(qm.SeestarQueuedStacker, "_run_astap_and_update_header", fake_run_astap)
+
+    hdr = qm.fits.Header()
+    hdr["CRPIX1"] = 5.0
+    hdr["CRPIX2"] = 5.0
+
+    data = np.ones((10, 10, 3), dtype=np.float32)
+    wht = np.ones((10, 10), dtype=np.float32)
+
+    sci, wht_paths = obj._save_and_solve_classic_batch(data, wht, hdr, 1)
+
+    assert calls["n"] == 2
+
+
 def test_calculate_fixed_orientation_grid():
     sys.path.insert(0, str(ROOT))
     import importlib


### PR DESCRIPTION
## Summary
- re-solve cropped master tiles with ASTAP so their WCS is consistent
- test that cropped tiles are solved twice when batch solving is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cdb987420832fad7e32ffb1aaf46d