### PR TITLE
Remove unused zoom setting

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -1055,25 +1055,6 @@ class SeestarStackerGUI:
         last_entry = ttk.Entry(last_frame, textvariable=self.last_stack_path, width=42)
         last_entry.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(5, 5))
 
-        zoom_frame = ttk.Frame(tab_stacking)
-        zoom_frame.pack(fill=tk.X, padx=5, pady=(0, 5))
-        ttk.Label(zoom_frame, text="Zoom (%)").grid(row=0, column=0, sticky=tk.W)
-        self.zoom_percent_var = tk.IntVar(value=0)
-        self.zoom_slider = ttk.Scale(
-            zoom_frame,
-            from_=-50,
-            to=50,
-            variable=self.zoom_percent_var,
-            orient=tk.HORIZONTAL,
-        )
-        self.zoom_slider.grid(row=0, column=1, sticky=tk.W, padx=(5, 0))
-        self.zoom_value_label = ttk.Label(
-            zoom_frame,
-            textvariable=self.zoom_percent_var,
-            width=4,
-            anchor="e",
-        )
-        self.zoom_value_label.grid(row=0, column=2, sticky=tk.W, padx=(5, 0))
 
         crop_frame = ttk.Frame(tab_stacking)
         crop_frame.pack(fill=tk.X, padx=5, pady=(0, 5))
@@ -6910,7 +6891,6 @@ class SeestarStackerGUI:
             "neighborhood_size": self.settings.neighborhood_size,
             "bayer_pattern": self.settings.bayer_pattern,
             "perform_cleanup": self.settings.cleanup_temp,
-            "zoom_percent": self.settings.zoom_percent,
             "use_weighting": self.settings.stack_weight_method == "quality",
             "weight_by_snr": self.settings.weight_by_snr,
             "weight_by_stars": self.settings.weight_by_stars,

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -203,11 +203,6 @@ class SettingsManager:
                 "cleanup_temp_var",
                 tk.BooleanVar(value=default_values_from_code.get("cleanup_temp", True)),
             ).get()
-            self.zoom_percent = getattr(
-                gui_instance,
-                "zoom_percent_var",
-                tk.IntVar(value=default_values_from_code.get("zoom_percent", 0)),
-            ).get()
             self.bayer_pattern = getattr(
                 gui_instance,
                 "bayer_pattern_var",
@@ -826,9 +821,6 @@ class SettingsManager:
             getattr(gui_instance, "cleanup_temp_var", tk.BooleanVar()).set(
                 self.cleanup_temp
             )
-            getattr(gui_instance, "zoom_percent_var", tk.IntVar()).set(
-                self.zoom_percent
-            )
 
             if not hasattr(self, "local_solver_preference"):
                 self.local_solver_preference = self.get_default_values()[
@@ -1229,7 +1221,6 @@ class SettingsManager:
         defaults_dict["hot_pixel_threshold"] = 3.0
         defaults_dict["neighborhood_size"] = 5
         defaults_dict["cleanup_temp"] = True
-        defaults_dict["zoom_percent"] = 0
 
         # --- Paramètres de Pondération par Qualité ---
         defaults_dict["use_quality_weighting"] = True
@@ -2434,7 +2425,6 @@ class SettingsManager:
             "hot_pixel_threshold": float(self.hot_pixel_threshold),
             "neighborhood_size": int(self.neighborhood_size),
             "cleanup_temp": bool(self.cleanup_temp),
-            "zoom_percent": int(self.zoom_percent),
             "use_quality_weighting": bool(self.use_quality_weighting),
             "weight_by_snr": bool(self.weight_by_snr),
             "weight_by_stars": bool(self.weight_by_stars),

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1089,7 +1089,6 @@ class SeestarQueuedStacker:
         self.stack_reject_algo = "none"
         self.hot_pixel_threshold = 3.0
         self.neighborhood_size = 5
-        self.zoom_percent = 0
         self.bayer_pattern = "GRBG"
         self.drizzle_mode = "Final"
         self.drizzle_scale = 2.0
@@ -5650,26 +5649,6 @@ class SeestarQueuedStacker:
                 except Exception as e_wb:
                     logger.debug(f"WARN QM [_process_file]: Erreur WB basique: {e_wb}")
 
-            zoom_pct = getattr(self, "zoom_percent", 0)
-            if isinstance(zoom_pct, (int, float)) and zoom_pct > 0:
-                factor = 1.0 + zoom_pct / 100.0
-                try:
-                    h, w = prepared_img_after_initial_proc.shape[:2]
-                    resized = cv2.resize(
-                        prepared_img_after_initial_proc,
-                        None,
-                        fx=factor,
-                        fy=factor,
-                        interpolation=cv2.INTER_CUBIC,
-                    )
-                    center = (resized.shape[1] // 2, resized.shape[0] // 2)
-                    prepared_img_after_initial_proc = cv2.getRectSubPix(
-                        resized,
-                        patchSize=(w, h),
-                        center=center,
-                    )
-                except Exception as e_zoom:
-                    logger.warning(f"Zoom ROI désactivé (erreur : {e_zoom})")
 
             if self.correct_hot_pixels:
                 prepared_img_after_initial_proc = detect_and_correct_hot_pixels(
@@ -10597,7 +10576,6 @@ class SeestarQueuedStacker:
         local_solver_preference="none",
         move_stacked=False,
         partial_save_interval=1,
-        zoom_percent=0,
         *,
         save_as_float32=False,
         preserve_linear_output=False,
@@ -10777,7 +10755,6 @@ class SeestarQueuedStacker:
         self.correct_hot_pixels = bool(correct_hot_pixels)
         self.hot_pixel_threshold = float(hot_pixel_threshold)
         self.neighborhood_size = int(neighborhood_size)
-        self.zoom_percent = int(zoom_percent)
         self.bayer_pattern = str(bayer_pattern) if bayer_pattern else "GRBG"
         self.perform_cleanup = bool(perform_cleanup)
         self.weight_by_snr = bool(weight_by_snr)


### PR DESCRIPTION
## Summary
- drop zoom slider from the stacking tab
- stop passing `zoom_percent` to the backend
- remove zoom option from settings manager
- delete zoom logic from `SeestarQueuedStacker`

## Testing
- `pytest -q`
- `pytest tests/test_worker_incremental_drizzle.py::test_worker_calls_incremental_drizzle -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3952a660832f852f4b6b023f780a