### PR TITLE
Fix misalignment in reproject and coadd

### DIFF
--- a/seestar/enhancement/mosaic_utils.py
+++ b/seestar/enhancement/mosaic_utils.py
@@ -4,6 +4,8 @@ from astropy.wcs import WCS
 
 from .reproject_utils import reproject_and_coadd, reproject_interp
 from .weight_utils import make_radial_weight_map
+from zemosaic import zemosaic_utils
+import inspect
 
 
 def assemble_final_mosaic_with_reproject_coadd(
@@ -34,9 +36,30 @@ def assemble_final_mosaic_with_reproject_coadd(
 
     if not master_tile_fits_with_wcs_list:
         return None, None
+    h, w = map(int, final_output_shape_hw)
+    try:
+        w_wcs = int(getattr(final_output_wcs, "pixel_shape", (w, h))[0])
+        h_wcs = int(getattr(final_output_wcs, "pixel_shape", (w, h))[1])
+    except Exception:
+        w_wcs = int(getattr(final_output_wcs.wcs, "naxis1", w)) if hasattr(final_output_wcs, "wcs") else w
+        h_wcs = int(getattr(final_output_wcs.wcs, "naxis2", h)) if hasattr(final_output_wcs, "wcs") else h
+    expected_hw = (h_wcs, w_wcs)
+    if (h, w) != expected_hw:
+        if (w, h) == expected_hw:
+            final_output_shape_hw = expected_hw
+            h, w = final_output_shape_hw
+        else:
+            return None, None
+
+    output_header = (
+        final_output_wcs.to_header()
+        if hasattr(final_output_wcs, "to_header")
+        else final_output_wcs
+    )
 
     channel_data = [[] for _ in range(3)]
     channel_wht = [[] for _ in range(3)]
+    wcs_list = []
 
     for path, wcs in master_tile_fits_with_wcs_list:
         try:
@@ -51,22 +74,36 @@ def assemble_final_mosaic_with_reproject_coadd(
         cov = np.ones(data.shape[:2], dtype=np.float32)
         cov *= make_radial_weight_map(*cov.shape)
 
+        wcs_list.append(wcs)
         for ch in range(data.shape[2]):
-            channel_data[ch].append((data[..., ch], wcs))
+            channel_data[ch].append(data[..., ch])
             channel_wht[ch].append(cov)
 
     mosaic_channels = []
     coverage = None
     for ch in range(3):
         try:
-            sci, cov = reproject_and_coadd(
-                channel_data[ch],
-                output_projection=final_output_wcs,
+            kwargs = {}
+            try:
+                sig = inspect.signature(reproject_and_coadd)
+                if "match_background" in sig.parameters:
+                    kwargs["match_background"] = match_bg
+                elif "match_bg" in sig.parameters:
+                    kwargs["match_bg"] = match_bg
+            except Exception:
+                kwargs["match_background"] = match_bg
+
+            sci, cov = zemosaic_utils.reproject_and_coadd_wrapper(
+                data_list=channel_data[ch],
+                wcs_list=wcs_list,
                 shape_out=final_output_shape_hw,
-                input_weights=channel_wht[ch],
+                output_projection=output_header,
+                use_gpu=False,
+                cpu_func=reproject_and_coadd,
                 reproject_function=reproject_interp,
                 combine_function="mean",
-                match_background=match_bg,
+                input_weights=channel_wht[ch],
+                **kwargs,
             )
         except Exception:
             return None, None


### PR DESCRIPTION
## Summary
- replicate ZeMosaic final-grid checks before reprojecting
- pass radial weights and handle match_background parameter dynamically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4da29ab4832fb683601215df2fcb