### PR TITLE
Remove duplicate WCS header parse

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -8900,12 +8900,6 @@ class SeestarQueuedStacker:
         final_stacked = stacked_np
         final_wht = wht_2d
         np.nan_to_num(final_wht, copy=False)
-        input_wcs = None
-        try:
-            input_wcs = WCS(header, naxis=2)
-        except Exception:
-            pass
-
         # Potential WCS present on the incoming header (e.g. from drizzle)
         input_wcs = None
         try:


### PR DESCRIPTION
## Summary
- simplify `_save_and_solve_classic_batch` by removing redundant `input_wcs` initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'photutils')*

------
https://chatgpt.com/codex/tasks/task_e_686e289bfe18832f83d9abcc5d668b1c