### PR TITLE
use astap settings in reproject coadd

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -8612,19 +8612,9 @@ class SeestarQueuedStacker:
         }
 
 
-        # For small stacked batches ASTAP may fail with a limited search radius.
-        # Force a blind search when using Reproject & Coadd to improve success
-        # rates. Use RA/DEC hints from the reference header when available.
-        if self.reproject_coadd_final:
-            solver_settings["astap_search_radius"] = 0.0
-            if (
-                self.reference_header_for_wcs is not None
-                and "CRVAL1" in self.reference_header_for_wcs
-                and "CRVAL2" in self.reference_header_for_wcs
-            ):
-                header.setdefault("RA", self.reference_header_for_wcs["CRVAL1"])
-                header.setdefault("DEC", self.reference_header_for_wcs["CRVAL2"])
-                solver_settings["use_radec_hints"] = True
+        # In Reproject & Coadd mode we now forward the user configured ASTAP
+        # options without forcing a blind search or RA/DEC hints.  This mirrors
+        # the simpler invocation used in ZeMosaic.
 
 
         self.update_progress(


### PR DESCRIPTION
## Summary
- do not override search radius or RA/DEC hints when solving the final stack
- rely on user-configured ASTAP options like in ZeMosaic

## Testing
- `pip install photutils`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e590c8888832fa1d03b7f49c20931