### PR TITLE
Enable macOS ASTAP app support

### DIFF
--- a/seestar/gui/local_solver_gui.py
+++ b/seestar/gui/local_solver_gui.py
@@ -4,6 +4,7 @@ Module pour la fenêtre de configuration des solveurs astrométriques locaux.
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import os  # Pour les opérations sur les chemins
+import platform
 from zemosaic import zemosaic_config
 from .ui_utils import ToolTip
 
@@ -483,10 +484,17 @@ class LocalSolverSettingsWindow(tk.Toplevel):
         elif os.path.exists(current_path):
              initial_dir = os.path.dirname(current_path)
 
-        file_types = [(self.tr("executable_files", default="Executable Files"), "*.*")] 
-        if os.name == 'nt': 
-            file_types = [(self.tr("astap_executable_win", default="ASTAP Executable"), "*.exe"), 
-                          (self.tr("all_files", default="All Files"), "*.*")]
+        file_types = [(self.tr("executable_files", default="Executable Files"), "*.*")]
+        if os.name == 'nt':
+            file_types = [
+                (self.tr("astap_executable_win", default="ASTAP Executable"), "*.exe"),
+                (self.tr("all_files", default="All Files"), "*.*"),
+            ]
+        elif platform.system() == "Darwin":
+            file_types = [
+                (self.tr("astap_app", default="ASTAP Application"), "*.app"),
+                (self.tr("all_files", default="All Files"), "*.*"),
+            ]
         
         filepath = filedialog.askopenfilename(
             title=self.tr("select_astap_executable_title", default="Select ASTAP Executable"),

--- a/seestar/gui/mosaic_gui.py
+++ b/seestar/gui/mosaic_gui.py
@@ -3,6 +3,7 @@ from tkinter import ttk, messagebox, filedialog
 # import traceback # Décommentez si besoin pour le debug
 import numpy as np 
 import os   # Pour les chemins de fichiers
+import platform
 # VALID_DRIZZLE_KERNELS est déjà défini dans votre fichier, je le garde.
 VALID_DRIZZLE_KERNELS = ['square', 'turbo', 'point', 'gaussian', 'lanczos2', 'lanczos3'] 
 
@@ -552,6 +553,11 @@ class MosaicSettingsWindow(tk.Toplevel):
         if os.name == 'nt':
             file_types = [
                 (self.parent_gui.tr("astap_executable_win", default="ASTAP Executable"), "*.exe"),
+                (self.parent_gui.tr("all_files", default="All Files"), "*.*"),
+            ]
+        elif platform.system() == "Darwin":
+            file_types = [
+                (self.parent_gui.tr("astap_app", default="ASTAP Application"), "*.app"),
                 (self.parent_gui.tr("all_files", default="All Files"), "*.*"),
             ]
 

--- a/tests/test_astrometry_solver.py
+++ b/tests/test_astrometry_solver.py
@@ -255,3 +255,16 @@ def test_astap_adds_fov_when_scale_missing(tmp_path, monkeypatch):
     )
 
     assert "-fov" in captured["cmd"]
+
+
+def test_resolve_astap_app(monkeypatch, tmp_path):
+    app_dir = tmp_path / "ASTAP.app"
+    bin_dir = app_dir / "Contents" / "MacOS"
+    bin_dir.mkdir(parents=True)
+    exe = bin_dir / "astap"
+    exe.write_text("")
+
+    monkeypatch.setattr(astrometry_solver.platform, "system", lambda: "Darwin")
+
+    resolved = astrometry_solver.resolve_astap_executable(str(app_dir))
+    assert resolved == str(exe)


### PR DESCRIPTION
## Summary
- support `.app` bundles for ASTAP on macOS
- expose macOS ASTAP executable in the GUI file pickers
- test resolution of ASTAP `.app` bundles

## Testing
- `pip install photutils astropy --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec8d4c204832fa6a50651edbafc0d