### PR TITLE
Add HQ RAM limit tooltip

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -1197,16 +1197,20 @@ class SeestarStackerGUI:
         self.stack_final_combo.pack(side=tk.LEFT, padx=(5, 0))
         self.stack_final_combo.bind("<<ComboboxSelected>>", self._on_final_combo_change)
 
-        tk.Label(
+        self.hq_ram_limit_label_widget = tk.Label(
             final_frame,
             text=self.tr("hq_ram_limit_label", default="HQ RAM limit (GB)")
-        ).pack(side=tk.LEFT, padx=(10, 2))
-        tk.Spinbox(
+        )
+        self.hq_ram_limit_label_widget.pack(side=tk.LEFT, padx=(10, 2))
+        self.hq_ram_limit_spinbox = tk.Spinbox(
             final_frame,
-            from_=1, to=64, increment=1,
+            from_=1,
+            to=64,
+            increment=1,
             width=5,
             textvariable=self.max_hq_mem_var,
-        ).pack(side=tk.LEFT)
+        )
+        self.hq_ram_limit_spinbox.pack(side=tk.LEFT)
 
         # Mapping between internal keys and displayed labels for normalization, weighting and final combine
         self.norm_keys = ["none", "linear_fit", "sky_mean"]
@@ -3292,6 +3296,7 @@ class SeestarStackerGUI:
             "stacking_winsor_limits_label": "winsor_limits_label",
             "stacking_winsor_note": "winsor_note_label",
             "stacking_final_combine_label": "final_combine_label",
+            "hq_ram_limit_label": "hq_ram_limit_label_widget",
             "wb_r": getattr(self, "wb_r_ctrls", {}).get("label"),
             "wb_g": getattr(self, "wb_g_ctrls", {}).get("label"),
             "wb_b": getattr(self, "wb_b_ctrls", {}).get("label"),
@@ -3416,6 +3421,8 @@ class SeestarStackerGUI:
             ("cb_max_b_factor_spinbox", "tooltip_cb_max_b_factor"),
             ("final_edge_crop_actual_label", "tooltip_final_edge_crop_percent"),
             ("final_edge_crop_spinbox", "tooltip_final_edge_crop_percent"),
+            ("hq_ram_limit_label_widget", "tooltip_hq_ram_limit"),
+            ("hq_ram_limit_spinbox", "tooltip_hq_ram_limit"),
             ("apply_final_scnr_check", "tooltip_apply_final_scnr"),
             (
                 getattr(self, "scnr_amount_ctrls", {}).get("label"),

--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -153,6 +153,7 @@ EN_TRANSLATIONS = {
     # Tooltips save_as_float32
     "tooltip_save_as_float32": "If checked, the final FITS file will be saved using 32-bit floating-point numbers, preserving the maximum numerical precision from processing but resulting in larger files (approx. 2x). If unchecked (default), the file will be saved as 16-bit unsigned integers (0-65535 range after scaling from 0-1), significantly reducing file size.",
     "tooltip_preserve_linear_output": "If enabled, skips percentile-based normalization before saving. The uint16 output will scale the raw 0-1 values directly to 0-65535.",
+    "tooltip_hq_ram_limit": "Max granted RAM for process",
     # ... end expert tab ...
     # --- Preview Tab ---
     "white_balance": "White Balance (Preview)",

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -181,6 +181,7 @@ FR_TRANSLATIONS = {
     # Tooltips save flaot32
     "tooltip_save_as_float32": "Si coché, le fichier FITS final sera sauvegardé en utilisant des nombres flottants 32 bits, préservant la précision numérique maximale du traitement mais résultant en des fichiers plus volumineux (env. 2x). Si décoché (défaut), le fichier sera sauvegardé en entiers non signés 16 bits (plage 0-65535 après mise à l'échelle depuis 0-1), réduisant significativement la taille du fichier.",
     "tooltip_preserve_linear_output": "Si activé, la normalisation par percentiles est ignorée avant la sauvegarde. La sortie uint16 sera l'échelle directe des valeurs 0-1 vers 0-65535.",
+    "tooltip_hq_ram_limit": "Mémoire RAM maximale accordée au processus",
     # --- FIN NOUVEAU ---
     ### FIN tooltips expert ###
     # --- Zone Progression ---


### PR DESCRIPTION
## Summary
- let GUI keep track of HQ RAM limit widgets
- map HQ RAM limit label in translation refresh table
- attach tooltip for the HQ RAM limit spinbox
- document tooltip text in English and French

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f85962ba8832f92221f1d68e9ab98