### PR TITLE
Fix reproject fallback when WCS axes differ

### DIFF
--- a/tests/test_reproject_utils.py
+++ b/tests/test_reproject_utils.py
@@ -37,3 +37,30 @@ def test_missing_reproject(monkeypatch):
     with pytest.raises(ImportError) as exc:
         module.reproject_and_coadd([], None, (1, 1))
     assert "pip install reproject" in str(exc.value)
+
+
+def test_fallback_on_wcs_mismatch(monkeypatch):
+    module = reproject_utils
+
+    def raise_value_error(*args, **kwargs):
+        raise ValueError("The two WCS return a different number of world coordinates")
+
+    monkeypatch.setattr(module, "_astropy_reproject_and_coadd", raise_value_error)
+
+    def dummy_reproj(data_wcs, output_projection=None, shape_out=None, **kwargs):
+        data, _ = data_wcs
+        return data[:shape_out[0], :shape_out[1]], np.ones(shape_out, dtype=float)
+
+    from astropy.wcs import WCS
+    import numpy as np
+
+    wcs = WCS(naxis=2)
+    wcs.pixel_shape = (1, 1)
+    result, cov = module.reproject_and_coadd(
+        [(np.ones((1, 1), dtype=np.float32), wcs)],
+        output_projection=wcs,
+        shape_out=(1, 1),
+        reproject_function=dummy_reproj,
+    )
+    assert np.allclose(result, 1)
+    assert np.allclose(cov, 1)


### PR DESCRIPTION
## Summary
- gracefully fallback to internal reproject algorithm when the Astropy implementation fails due to WCS mismatch
- add regression test for the fallback behaviour

## Testing
- `pytest tests/test_reproject_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc77de330832f8128a570176ac95a