### PR TITLE
Bug fix for reproject and coadd shape handling

### DIFF
--- a/seestar/enhancement/reproject_utils.py
+++ b/seestar/enhancement/reproject_utils.py
@@ -85,7 +85,7 @@ def reproject_and_coadd(
                 raise
 
     ref_wcs = WCS(output_projection) if not isinstance(output_projection, WCS) else output_projection
-    shape_out = tuple(shape_out)
+    shape_out = tuple(int(round(x)) for x in shape_out)
 
     sum_image = np.zeros(shape_out, dtype=np.float64)
     cov_image = np.zeros(shape_out, dtype=np.float64)


### PR DESCRIPTION
## Summary
- ensure `reproject_and_coadd` converts shape values to integers
- run test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fdf1415cc832f8df35d0db06e9bb0