### PR TITLE
Bug fix for non-celestial WCS in reproject

### DIFF
--- a/tests/test_reproject_utils.py
+++ b/tests/test_reproject_utils.py
@@ -91,3 +91,38 @@ def test_fallback_on_generic_error(monkeypatch):
     )
     assert np.allclose(result, 1)
     assert np.allclose(cov, 1)
+
+
+def test_skip_non_celestial_inputs(monkeypatch):
+    module = reproject_utils
+
+    def dummy_reproj(data_wcs, output_projection=None, shape_out=None, **kwargs):
+        data, _ = data_wcs
+        return data[: shape_out[0], : shape_out[1]], np.ones(shape_out, dtype=float)
+
+    monkeypatch.setattr(
+        module,
+        "_astropy_reproject_and_coadd",
+        lambda *a, **k: (_ for _ in ()).throw(ValueError("Output WCS has celestial components but input WCS does not")),
+    )
+
+    from astropy.wcs import WCS
+    import numpy as np
+
+    wcs_cel = WCS(naxis=2)
+    wcs_cel.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    wcs_cel.pixel_shape = (1, 1)
+
+    wcs_non = WCS(naxis=2)
+    wcs_non.wcs.ctype = ["LON", "LAT"]
+    wcs_non.pixel_shape = (1, 1)
+
+    result, cov = module.reproject_and_coadd(
+        [(np.ones((1, 1), dtype=np.float32), wcs_non), (np.ones((1, 1), dtype=np.float32), wcs_cel)],
+        output_projection=wcs_cel,
+        shape_out=(1, 1),
+        reproject_function=dummy_reproj,
+    )
+
+    assert np.allclose(result, 1)
+    assert np.allclose(cov, 1)


### PR DESCRIPTION
## Summary
- handle inputs lacking celestial WCS in `reproject_and_coadd`
- warn and skip those images instead of failing
- test skipping of non-celestial inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fdf1415cc832f8df35d0db06e9bb0