### PR TITLE
Fix temp_processing path handling

### DIFF
--- a/seestar/core/alignment.py
+++ b/seestar/core/alignment.py
@@ -469,7 +469,12 @@ class SeestarAligner:
         dans le dossier temporaire DEDANS base_output_folder.
         """
         if reference_image is None: return
-        temp_folder_ref = os.path.join(base_output_folder, "temp_processing")
+        # On permet de passer directement un chemin qui est déjà le dossier
+        # temp_processing pour éviter de dupliquer ce segment dans certains cas
+        if os.path.basename(os.path.normpath(base_output_folder)) == "temp_processing":
+            temp_folder_ref = base_output_folder
+        else:
+            temp_folder_ref = os.path.join(base_output_folder, "temp_processing")
         try:
             os.makedirs(temp_folder_ref, exist_ok=True)
             ref_output_path = os.path.join(temp_folder_ref, "reference_image.fit")

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3102,9 +3102,7 @@ class SeestarQueuedStacker:
                         "unknown_reference_panel.fits"  # Fallback
                     )
 
-            ref_temp_processing_dir = os.path.join(
-                self.output_folder, "temp_processing"
-            )
+            ref_temp_processing_dir = self._temp_processing_dir()
             reference_image_path_for_solver = os.path.join(
                 ref_temp_processing_dir, "reference_image.fit"
             )
@@ -10503,6 +10501,16 @@ class SeestarQueuedStacker:
             except Exception:
                 pass
 
+    ##########################################################################
+    ####################################################################
+
+    def _temp_processing_dir(self) -> str:
+        """Return the path to the temporary processing directory."""
+        base = os.path.abspath(self.output_folder) if self.output_folder else ""
+        if os.path.basename(os.path.normpath(base)) == "temp_processing":
+            return base
+        return os.path.join(base, "temp_processing")
+
     ################################################################################################################################################
 
     def cleanup_temp_reference(self):
@@ -10512,7 +10520,7 @@ class SeestarQueuedStacker:
             )
             return
         try:
-            aligner_temp_folder = os.path.join(self.output_folder, "temp_processing")
+            aligner_temp_folder = self._temp_processing_dir()
             if os.path.isdir(aligner_temp_folder):
                 ref_fit = os.path.join(aligner_temp_folder, "reference_image.fit")
                 ref_png = os.path.join(aligner_temp_folder, "reference_image.png")
@@ -11229,9 +11237,7 @@ class SeestarQueuedStacker:
                 f"DEBUG QM (start_processing): Shape de référence HWC déterminée: {ref_shape_hwc}"
             )
 
-            ref_temp_processing_dir = os.path.join(
-                self.output_folder, "temp_processing"
-            )
+            ref_temp_processing_dir = self._temp_processing_dir()
             reference_image_path_for_solving = os.path.join(
                 ref_temp_processing_dir, "reference_image.fit"
             )


### PR DESCRIPTION
## Summary
- avoid duplicate temp_processing folder when saving reference image
- centralize temp processing path logic with helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68700e4939ec832f99dbff0e24cd57ea