### PR TITLE
Fix final stack alignment with reproject-coadd

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4374,9 +4374,9 @@ class SeestarQueuedStacker:
                             self._finalize_single_classic_batch(
                                 self.intermediate_classic_batch_files[0]
                             )
-                        elif not self._reproject_classic_batches_zm(
-                            self.intermediate_classic_batch_files
-                        ):
+                        else:
+                            # Directly use the alignment-safe implementation
+                            # to avoid blur when combining pre-stacked batches.
                             self._reproject_classic_batches(
                                 self.intermediate_classic_batch_files
                             )
@@ -9280,7 +9280,15 @@ class SeestarQueuedStacker:
         self.current_stack = np.stack(final_channels, axis=-1)
         self.current_coverage = final_cov
 
-        # Caller will take care of saving the FITS file / updating GUI, etc.
+        self.current_stack_header = fits.Header()
+        self.current_stack_header.update(out_wcs.to_header(relax=True))
+
+        self._save_final_stack(
+            "_classic_reproject",
+            drizzle_final_sci_data=self.current_stack,
+            drizzle_final_wht_data=self.current_coverage,
+            preserve_linear_output=True,
+        )
 
     def _crop_to_reference_wcs(self, img_hwc, cov_hw, mosaic_wcs):
         """Crop a mosaic to the current reference WCS if available."""


### PR DESCRIPTION
## Summary
- ensure classic batch reprojection saves final results when used for Reproject&Coadd mode

## Testing
- `pytest tests/test_queue_manager_reproject.py::test_reproject_classic_batches_uses_fixed -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873a4bd8838832f9b14c1f5e45128ff