### PR TITLE
Fix black output when using reproject & coadd

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -5414,6 +5414,7 @@ class SeestarQueuedStacker:
                 output_filename_suffix="_mosaic_reproject",
                 drizzle_final_sci_data=final_sci_image_HWC,
                 drizzle_final_wht_data=final_coverage_map_2D,
+                preserve_linear_output=True,
             )
         except Exception as e_stack_final:
             self.update_progress(


### PR DESCRIPTION
## Summary
- ensure that the final mosaic created with reproject_and_coadd keeps its linear intensity range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873dd6d26d4832f855818e5b005db11