### PR TITLE
Fix black output in reproject mode

### DIFF
--- a/seestar/enhancement/mosaic_utils.py
+++ b/seestar/enhancement/mosaic_utils.py
@@ -152,6 +152,9 @@ def assemble_final_mosaic_with_reproject_coadd(
 
                 **kwargs_local,
             )
+            # Avoid propagating NaNs which can lead to black images
+            sci = np.nan_to_num(sci, nan=0.0)
+            cov = np.nan_to_num(cov, nan=0.0)
         except Exception:
             return None, None
         mosaic_channels.append(sci.astype(np.float32))


### PR DESCRIPTION
## Summary
- sanitize output of `reproject_and_coadd_wrapper` to avoid NaNs

## Testing
- `pytest tests/test_reproject_utils.py -q`
- `pytest tests/test_queue_manager_reproject.py::test_reproject_to_reference_rgb -q`
- `pytest tests/test_mosaic_worker.py::test_temp_header_clean -q`


------
https://chatgpt.com/codex/tasks/task_e_6873e1c088ec832fb1d6c0089f1b1471