### PR TITLE
Fix linear output option in Reproject+Coadd

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -5414,7 +5414,7 @@ class SeestarQueuedStacker:
                 output_filename_suffix="_mosaic_reproject",
                 drizzle_final_sci_data=final_sci_image_HWC,
                 drizzle_final_wht_data=final_coverage_map_2D,
-                preserve_linear_output=True,
+                preserve_linear_output=self.preserve_linear_output,
             )
         except Exception as e_stack_final:
             self.update_progress(
@@ -9319,7 +9319,7 @@ class SeestarQueuedStacker:
             "_classic_reproject",
             drizzle_final_sci_data=self.current_stack,
             drizzle_final_wht_data=self.current_coverage,
-            preserve_linear_output=True,
+            preserve_linear_output=self.preserve_linear_output,
         )
 
     def _crop_to_reference_wcs(self, img_hwc, cov_hw, mosaic_wcs):
@@ -9497,7 +9497,7 @@ class SeestarQueuedStacker:
             "_classic_reproject_zm",
             drizzle_final_sci_data=data_hwc,
             drizzle_final_wht_data=cov_hw,
-            preserve_linear_output=True,
+            preserve_linear_output=self.preserve_linear_output,
         )
         return True
     def _finalize_single_classic_batch(self, batch_file_tuple):
@@ -9520,7 +9520,7 @@ class SeestarQueuedStacker:
             "_classic_reproject",
             drizzle_final_sci_data=data,
             drizzle_final_wht_data=cov,
-            preserve_linear_output=True,
+            preserve_linear_output=self.preserve_linear_output,
         )
 
     ############################################################################################################################################


### PR DESCRIPTION
## Summary
- ensure Reproject+Coadd respects `preserve_linear_output` when saving final stacks

## Testing
- `pytest tests/test_queue_manager_reproject.py::test_reproject_classic_batches_uses_fixed tests/test_save_final_stack.py::test_save_final_stack_preserve_linear_float32 -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e65db018832fb80d1511e2f4c9a6