### PR TITLE
Fix color orientation

### DIFF
--- a/seestar/enhancement/reproject_utils.py
+++ b/seestar/enhancement/reproject_utils.py
@@ -75,6 +75,12 @@ def reproject_and_coadd(
         if ref_wcs.has_celestial and not getattr(wcs_obj, "has_celestial", False):
             logger.warning("Skipping input without celestial WCS")
             continue
+
+        if img.ndim == 3 and img.shape[0] in (1, 3) and img.shape[-1] != img.shape[0]:
+            img = np.moveaxis(img, 0, -1)
+        if weight is not None and weight.ndim == img.ndim and weight.shape[0] in (1, 3) and weight.shape[-1] != weight.shape[0]:
+            weight = np.moveaxis(weight, 0, -1)
+
         filtered_pairs.append((img, wcs_obj))
         filtered_weights.append(weight)
 
@@ -100,11 +106,48 @@ def reproject_and_coadd(
                 **kwargs,
             )
         except Exception as exc:  # pragma: no cover - depends on reproject version
-            msg = str(exc)
-            if "different number of world coordinates" not in msg.lower() and "output" not in msg.lower():
-                raise
+            logger.warning(
+                "astropy reproject_and_coadd failed: %s; falling back to numpy implementation",
+                exc,
+            )
 
-    sum_image = np.zeros(shape_out, dtype=np.float64)
+    first_img = filtered_pairs[0][0]
+    if first_img.ndim == 3:
+        n_channels = first_img.shape[2]
+    else:
+        n_channels = 1
+
+    if n_channels > 1:
+        channel_results = []
+        cov_image = None
+        for ch in range(n_channels):
+            ch_pairs = []
+            for img, wcs_in in filtered_pairs:
+                if img.ndim == 3:
+                    ch_pairs.append((img[..., ch], wcs_in))
+                else:
+                    ch_pairs.append((img, wcs_in))
+            ch_res, cov = reproject_and_coadd(
+                ch_pairs,
+                output_projection=ref_wcs,
+                shape_out=shape_out,
+                input_weights=filtered_weights,
+                reproject_function=reproject_function,
+                combine_function=combine_function,
+                match_background=match_background,
+                **kwargs,
+            )
+            channel_results.append(ch_res)
+            if cov_image is None:
+                cov_image = cov
+            else:
+                cov_image = np.maximum(cov_image, cov)
+        mosaic = np.stack(channel_results, axis=-1)
+        return mosaic.astype(np.float32), cov_image.astype(np.float32)
+
+    sum_shape = shape_out
+
+    sum_image = np.zeros(sum_shape, dtype=np.float64)
     cov_image = np.zeros(shape_out, dtype=np.float64)
 
 
@@ -122,12 +165,20 @@ def reproject_and_coadd(
             w_reproj = np.nan_to_num(w_reproj, nan=0.0)
             weight_proj = w_reproj * w_fp
 
-        sum_image += proj_img * weight_proj
+        if n_channels == 1:
+            sum_image += proj_img * weight_proj
+        else:
+            if proj_img.ndim == 2:
+                proj_img = np.repeat(proj_img[:, :, None], n_channels, axis=2)
+            sum_image += proj_img * weight_proj[:, :, None]
         cov_image += weight_proj
 
-    final = np.full(shape_out, np.nan, dtype=np.float64)
+    final = np.full(sum_shape, np.nan, dtype=np.float64)
     valid = cov_image > 0
-    final[valid] = sum_image[valid] / cov_image[valid]
+    if n_channels == 1:
+        final[valid] = sum_image[valid] / cov_image[valid]
+    else:
+        final[valid] = sum_image[valid] / cov_image[valid][..., None]
 
     return final.astype(np.float32), cov_image.astype(np.float32)
 

--- a/tests/test_reproject_utils.py
+++ b/tests/test_reproject_utils.py
@@ -132,3 +132,29 @@ def test_skip_non_celestial_inputs(monkeypatch):
 
     assert np.allclose(result, 1)
     assert np.allclose(cov, 1)
+
+
+def test_channel_orientation_chw(monkeypatch):
+    module = reproject_utils
+
+    def dummy_reproj(data_wcs, output_projection=None, shape_out=None, **kwargs):
+        data, _ = data_wcs
+        return data[: shape_out[0], : shape_out[1]], np.ones(shape_out, dtype=float)
+
+    from astropy.wcs import WCS
+    import numpy as np
+
+    wcs = WCS(naxis=2)
+    wcs.pixel_shape = (1, 1)
+
+    chw_data = np.ones((3, 1, 1), dtype=np.float32)
+    result, cov = module.reproject_and_coadd(
+        [(chw_data, wcs)],
+        output_projection=wcs,
+        shape_out=(1, 1),
+        reproject_function=dummy_reproj,
+    )
+
+    assert result.shape == (1, 1, 3)
+    assert np.allclose(result, 1)
+    assert np.allclose(cov, 1)


### PR DESCRIPTION
## Summary
- fix CHW color inputs when reprojecting mosaics
- test handling of CHW orientation

## Testing
- `pytest tests/test_reproject_utils.py::test_channel_orientation_chw -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f1ba2e9c832f8feb46ad2073927d