### PR TITLE
Handle zero coverage in reproject fallback

### DIFF
--- a/seestar/enhancement/mosaic_utils.py
+++ b/seestar/enhancement/mosaic_utils.py
@@ -173,6 +173,9 @@ def assemble_final_mosaic_with_reproject_coadd(
 
                 **kwargs_local,
             )
+            if not np.any(cov > 0):
+                sci = np.mean(np.stack(data_list, axis=0), axis=0).astype(np.float32)
+                cov = np.ones(final_output_shape_hw, dtype=np.float32)
         except Exception:
             return None, None
         mosaic_channels.append(sci.astype(np.float32))


### PR DESCRIPTION
## Summary
- avoid empty mosaic when `reproject_and_coadd` returns zero coverage

## Testing
- `pytest -q tests/test_mosaic_worker.py::test_temp_header_clean -q`
- `pytest -q tests/test_mosaic_worker.py::test_use_sidecar_wcs -q`


------
https://chatgpt.com/codex/tasks/task_e_68742953adec832fb02f912e548f7337