### PR TITLE
Add final edge crop before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Seestar Stacker est une application graphique conçue pour aligner et empiler de
 *   **Configuration:** Saves and loads user settings (`seestar_settings.json`).
 *   **Output Format:** Save FITS stacks as float32 or uint16. Enable *Preserve Linear Output* to skip percentile scaling.
 *   **Workflow Tools:** Add folders during processing, Copy Log button, Open Output Folder button, optional temporary file cleanup.
+*   **Final Edge Crop:** Optionally crop a small percentage from the stacked image edges before saving (WCS adjusted).
 *   **Smart Quality Control:**
     *   SNR-based weighting
     *   Star count/sharpness analysis
@@ -62,6 +63,7 @@ written linearly.
 *   **Configuration :** Sauvegarde et charge les paramètres utilisateur (`seestar_settings.json`).
 *   **Format de Sortie :** Sauvegarde des FITS en float32 ou uint16. Activez *Préserver l'image linéaire* pour éviter la normalisation par percentiles.
 *   **Outils de Workflow :** Ajout de dossiers pendant le traitement, bouton Copier Log, bouton Ouvrir Dossier Sortie, nettoyage optionnel des fichiers temporaires.
+*   **Rognage Final des Bords :** Rogne automatiquement un petit pourcentage des bords de l'image finale avec mise à jour du WCS.
 *   **Contrôle Qualité Intelligent :**
     *   Pondération par rapport signal/bruit (SNR)
     *   Analyse du nombre/netteté des étoiles


### PR DESCRIPTION
## Summary
- crop final image edges if configured in `_save_final_stack`
- test that cropping modifies FITS size and WCS
- document the optional edge crop feature

## Testing
- `pytest -q tests/test_save_final_stack.py::test_final_edge_crop`

------
https://chatgpt.com/codex/tasks/task_e_6874953b39ec832fa72840f25f677f20