### PR TITLE
Fix final save for reproject-coadd

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4397,6 +4397,12 @@ class SeestarQueuedStacker:
                                 self._reproject_classic_batches(
                                     self.intermediate_classic_batch_files
                                 )
+                                self._save_final_stack(
+                                    "_classic_reproject",
+                                    drizzle_final_sci_data=self.current_stack,
+                                    drizzle_final_wht_data=self.current_coverage,
+                                    preserve_linear_output=True,
+                                )
                             except Exception as e:
                                 self.update_progress(
                                     f"⚠️ _reproject_classic_batches échoué: {e}; utilisation du fallback ZeMosaic.",


### PR DESCRIPTION
## Summary
- ensure the final FITS/PNG are produced when using the *reproject & coadd* mode

## Testing
- `python -m py_compile seestar/queuep/queue_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6874c6d3b9f4832fa026d217c59e2281