### PR TITLE
Fix batch reprojection alignment

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9243,20 +9243,11 @@ class SeestarQueuedStacker:
                     else (h, w)
                 )
 
-                # Science image (3‑channels)
-                img_hwc = reproject_to_reference_wcs(
-                    np.moveaxis(data_cxhxw, 0, -1),  # CxHxW ➜ HxWxC
-                    batch_wcs,
-                    self.reference_wcs_object,
-                    (tgt_h, tgt_w),
-                )
-
-                # Weight map – single channel, same helper works
-                coverage = reproject_to_reference_wcs(
+                # ↳ Version sûre : boucle sur les canaux + carte de poids
+                img_hwc, coverage = self._reproject_batch_to_reference(
+                    np.moveaxis(data_cxhxw, 0, -1),   # CxHxW → HxWxC
                     coverage,
                     batch_wcs,
-                    self.reference_wcs_object,
-                    (tgt_h, tgt_w),
                 )
 
                 batch_wcs = self.reference_wcs_object  # Subsequent code must use it


### PR DESCRIPTION
## Summary
- use `_reproject_batch_to_reference` in `_reproject_classic_batches`
- ensure weight map and RGB cube are reprojected identically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874db99ded8832f95efd3559ebbb2ba