### PR TITLE
Fix import for classic batch reprojection

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -9332,8 +9332,15 @@ class SeestarQueuedStacker:
             from seestar.enhancement.mosaic_utils import (
                 assemble_final_mosaic_with_reproject_coadd,
             )
+            from seestar.enhancement.reproject_utils import (
+                reproject_and_coadd,
+                reproject_interp,
+            )
         except Exception as e:
-            self.update_progress(f"⚠️ assemble_final_mosaic_with_reproject_coadd indisponible: {e}", "WARN")
+            self.update_progress(
+                f"⚠️ assemble_final_mosaic_with_reproject_coadd indisponible: {e}",
+                "WARN",
+            )
             return False
 
         channel_arrays_wcs = [[] for _ in range(3)]


### PR DESCRIPTION
## Summary
- ensure `_reproject_classic_batches_zm` imports `reproject_and_coadd` and `reproject_interp`

## Testing
- `pytest tests/test_queue_manager_reproject.py::test_reproject_to_reference_rgb -q`
- `pytest tests/test_reproject_utils.py::test_functions_callable -q`
- `pytest tests/test_mosaic_worker.py::test_crop_pixel_shape_passed -q`


------
https://chatgpt.com/codex/tasks/task_e_68750244cef0832f9358192d748c7e19