### PR TITLE
Fix fallback grid for reproject mode

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -2541,7 +2541,12 @@ class SeestarQueuedStacker:
         except Exception as e:
             logger.error("find_optimal_celestial_wcs unavailable: %s", e)
             find_optimal_celestial_wcs = None
-        _fallback_grid = None
+
+        from ..core.reprojection_utils import compute_final_output_grid
+
+        def _fallback_grid(wcs_list, shapes_hw_list, scale_factor):
+            header_infos = list(zip(shapes_hw_list, wcs_list))
+            return compute_final_output_grid(header_infos, scale=scale_factor)
 
         valid_wcs = []
         valid_shapes_hw = []


### PR DESCRIPTION
## Summary
- add fallback grid in `_calculate_final_mosaic_grid` using `compute_final_output_grid`
- ensure a valid output WCS is returned when `find_optimal_celestial_wcs` fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751d3632c8832f8f7f11051c410d09