### PR TITLE
Fix final reproject grid orientation

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -8950,6 +8950,7 @@ class SeestarQueuedStacker:
             wcs_list,
             headers,
             scale_factor=scale_factor,
+            auto_rotate=True,
         )
         if out_wcs is None or out_shape is None:
             self.update_progress("⚠️ Échec du calcul de la grille finale.", "WARN")


### PR DESCRIPTION
## Summary
- compute final mosaic grid with `auto_rotate=True` for cached files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875239f9d8c832f889b88956b2b00da