### PR TITLE
Fix reproject+coadd batches

### DIFF
--- a/seestar/core/weights.py
+++ b/seestar/core/weights.py
@@ -1,9 +1,28 @@
 import numpy as np
 from astropy.stats import sigma_clipped_stats, SigmaClip
-from photutils.background import Background2D, MedianBackground
-from photutils.detection import DAOStarFinder
-from photutils.segmentation import detect_sources
-from photutils.segmentation import SourceCatalog
+try:
+    from photutils.background import Background2D, MedianBackground
+    from photutils.detection import DAOStarFinder
+    from photutils.segmentation import detect_sources
+    from photutils.segmentation import SourceCatalog
+    _PHOTUTILS_AVAILABLE = True
+except Exception:
+    _PHOTUTILS_AVAILABLE = False
+
+    class Background2D:  # type: ignore
+        pass
+
+    class MedianBackground:  # type: ignore
+        pass
+
+    class DAOStarFinder:  # type: ignore
+        pass
+
+    def detect_sources(*a, **k):  # type: ignore
+        return None
+
+    class SourceCatalog:  # type: ignore
+        pass
 
 
 def _calculate_image_weights_noise_variance(image_list, progress_callback=None):


### PR DESCRIPTION
## Summary
- preserve RA/DEC info in classic batch headers when solving is deferred
- avoid photutils import errors by stubbing optional imports
- add regression test ensuring batch headers contain RA/DEC and TOTEXP

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876044984c0832f900900294f20afeb