### PR TITLE
Implement auto background reference selection

### DIFF
--- a/seestar/enhancement/mosaic_utils.py
+++ b/seestar/enhancement/mosaic_utils.py
@@ -1,13 +1,110 @@
+import logging
+import os
+import shutil
+import inspect
+from typing import Tuple
+
 import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
 
+from scipy.ndimage import binary_dilation
+
 from .reproject_utils import reproject_and_coadd, reproject_interp
 
 from zemosaic import zemosaic_utils
-import inspect
-import os
-import shutil
+
+logger = logging.getLogger(__name__)
+
+try:
+    from photutils.detection import DAOStarFinder
+    from astropy.stats import sigma_clipped_stats
+    _PHOTUTILS_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    DAOStarFinder = None  # type: ignore
+    sigma_clipped_stats = None  # type: ignore
+    _PHOTUTILS_AVAILABLE = False
+
+
+def detect_stars(img: np.ndarray) -> np.ndarray:
+    """Return boolean mask of detected stars in ``img``.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        2-D input image.
+
+    Returns
+    -------
+    np.ndarray
+        Boolean mask where ``True`` indicates stellar pixels.
+    """
+
+    if not _PHOTUTILS_AVAILABLE:
+        raise ImportError("photutils is required for detect_stars")
+
+    if img.ndim != 2:
+        raise ValueError("detect_stars expects a 2-D array")
+
+    mean, median, std = sigma_clipped_stats(img, sigma=3.0, maxiters=5)
+    daofind = DAOStarFinder(fwhm=3.0, threshold=5.0 * std)
+    sources = daofind(img - median)
+    mask = np.zeros_like(img, dtype=bool)
+    if sources is not None and len(sources) > 0:
+        y, x = sources["ycentroid"].astype(int), sources["xcentroid"].astype(int)
+        y = np.clip(y, 0, img.shape[0] - 1)
+        x = np.clip(x, 0, img.shape[1] - 1)
+        mask[y, x] = True
+    if mask.any():
+        mask = binary_dilation(mask, iterations=2)
+    return mask
+
+
+def _background_metrics(img: np.ndarray, star_mask: np.ndarray) -> Tuple[float, float, float]:
+    """Compute background statistics for ``img`` excluding stars."""
+
+    if img.ndim != 2:
+        raise ValueError("_background_metrics expects a 2-D array")
+
+    if img.shape != star_mask.shape:
+        raise ValueError("star_mask must match image shape")
+
+    sample = img
+    mask = star_mask
+    if max(img.shape) > 2048:
+        step = 4
+        sample = img[::step, ::step]
+        mask = star_mask[::step, ::step]
+
+    background_pixels = sample[~mask]
+    med = float(np.median(background_pixels)) if background_pixels.size else 0.0
+    mad = float(np.median(np.abs(background_pixels - med))) if background_pixels.size else 0.0
+    noise = mad * 1.4826
+
+    y, x = np.indices(sample.shape)
+    A = np.column_stack((x[~mask].ravel(), y[~mask].ravel(), np.ones(np.count_nonzero(~mask))))
+    b = sample[~mask].ravel()
+    try:
+        coeffs, *_ = np.linalg.lstsq(A, b, rcond=None)
+        plane = coeffs[0] * x + coeffs[1] * y + coeffs[2]
+    except Exception:
+        plane = np.zeros_like(sample, dtype=float)
+    residual = sample - plane
+    gy, gx = np.gradient(residual)
+    grad = np.sqrt(gx ** 2 + gy ** 2)
+    grad_rms = float(np.sqrt(np.mean(grad[~mask] ** 2))) if np.any(~mask) else 0.0
+    return med, noise, grad_rms
+
+
+def coverage_fraction(idx: int, footprints: np.ndarray) -> float:
+    """Return fraction of well-covered pixels for image ``idx``."""
+
+    if footprints.ndim != 3:
+        raise ValueError("footprints must be 3-D array")
+    fp = footprints[idx] > 0
+    overlap = (footprints > 0).sum(axis=0)
+    good = fp & (overlap >= 2)
+    return float(np.count_nonzero(good)) / float(fp.size)
 
 
 
@@ -20,6 +117,8 @@ def assemble_final_mosaic_with_reproject_coadd(
     use_memmap: bool = False,
     memmap_dir: str | None = None,
     cleanup_memmap: bool = True,
+    auto_bg_reference: bool = True,
+    force_reference_index: int | None = None,
 ):
     """Assemble master tiles using ``reproject_and_coadd``.
 
@@ -45,6 +144,12 @@ def assemble_final_mosaic_with_reproject_coadd(
     cleanup_memmap : bool, optional
         When ``True`` the memmap directory will be removed once stacking
         completes.
+    auto_bg_reference : bool, optional
+        When ``True`` and background matching is enabled, automatically select
+        the best reference image for background normalization.
+    force_reference_index : int, optional
+        If provided, override automatic selection and use this index as the
+        background reference.
 
     Returns
     -------
@@ -105,6 +210,59 @@ def assemble_final_mosaic_with_reproject_coadd(
             memmap_dir = os.path.join(os.getcwd(), "reproject_memmap")
         os.makedirs(memmap_dir, exist_ok=True)
 
+    best_ref = None
+    if auto_bg_reference and match_bg:
+        footprints = []
+        for arr, wcs in zip(data_all, wcs_list):
+            try:
+                _, fp = reproject_interp(
+                    (arr[..., 0], wcs),
+                    output_projection=header,
+                    shape_out=final_output_shape_hw,
+                )
+            except Exception:
+                fp = np.zeros(final_output_shape_hw, dtype=float)
+            footprints.append(fp)
+        footprints = np.stack(footprints, axis=0)
+
+        metrics = []
+        for i, arr in enumerate(data_all):
+            img_ch = arr[..., 1] if arr.shape[-1] > 1 else arr[..., 0]
+            try:
+                star_mask = detect_stars(img_ch)
+            except Exception as exc:  # pragma: no cover - photutils missing
+                logger.debug("Star detection failed: %s", exc)
+                star_mask = np.zeros_like(img_ch, dtype=bool)
+            med, noise, grad = _background_metrics(img_ch, star_mask)
+            cover = coverage_fraction(i, footprints)
+            metrics.append((med, noise, grad, cover))
+
+        global_median = float(np.median([m[0] for m in metrics])) if metrics else 0.0
+        scores = []
+        for i, (med, noise, grad, cover) in enumerate(metrics):
+            score = abs(med - global_median) + noise + 2.0 * grad - 0.5 * cover
+            scores.append(score)
+        if scores:
+            best_ref = int(np.argmin(scores))
+
+        if force_reference_index is not None and 0 <= force_reference_index < len(data_all):
+            best_ref = int(force_reference_index)
+
+        for i, (met, sc) in enumerate(zip(metrics, scores)):
+            flag = " <-- REF" if best_ref is not None and i == best_ref else ""
+            logger.debug(
+                "BG_METRICS idx=%d med=%.3f noise=%.3f grad=%.3f cover=%.3f score=%.3f%s",
+                i,
+                met[0],
+                met[1],
+                met[2],
+                met[3],
+                sc,
+                flag,
+            )
+        if best_ref is not None:
+            logger.debug("Selected background reference index: %d", best_ref)
+
     for ch in range(n_ch):
         try:
 
@@ -134,9 +292,14 @@ def assemble_final_mosaic_with_reproject_coadd(
                         kwargs_local["memmap_dir"] = memmap_dir
                     if "cleanup_memmap" in sig.parameters:
                         kwargs_local["cleanup_memmap"] = False
+                if auto_bg_reference and match_bg and best_ref is not None:
+                    if "background_reference" in sig.parameters:
+                        kwargs_local["background_reference"] = best_ref
             except Exception:
                 if use_memmap and "memmap_dir" not in kwargs_local:
                     kwargs_local["memmap_dir"] = memmap_dir
+                if auto_bg_reference and match_bg and best_ref is not None:
+                    kwargs_local["background_reference"] = best_ref
 
             sci, cov = zemosaic_utils.reproject_and_coadd_wrapper(
                 data_list=data_list,

--- a/tests/test_auto_bg_reference.py
+++ b/tests/test_auto_bg_reference.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+import importlib
+import numpy as np
+from astropy.wcs import WCS
+from astropy.io import fits
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+mosaic_utils = importlib.import_module("seestar.enhancement.mosaic_utils")
+
+
+def make_wcs(shape=(10, 10)):
+    w = WCS(naxis=2)
+    w.wcs.crpix = [shape[1] / 2, shape[0] / 2]
+    w.wcs.cdelt = np.array([-0.01, 0.01])
+    w.wcs.crval = [0, 0]
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    w.pixel_shape = (shape[1], shape[0])
+    return w
+
+
+def test_auto_background_reference(monkeypatch, tmp_path):
+    wcs = make_wcs()
+    data0 = np.zeros((10, 10), dtype=np.float32)
+    data1 = np.zeros((10, 10), dtype=np.float32) + 100
+    data2 = np.zeros((10, 10), dtype=np.float32) + 200
+    paths = []
+    for i, data in enumerate([data0, data1, data2]):
+        path = tmp_path / f"img{i}.fits"
+        fits.writeto(path, data, overwrite=True)
+        paths.append((str(path), wcs))
+
+    captured = {}
+
+    def dummy_reproject_and_coadd(input_pairs, output_projection, shape_out, match_background=True, background_reference=None, **kwargs):
+        meds = [np.median(img) for img, _ in input_pairs]
+        ref = meds[background_reference] if background_reference is not None else np.median(meds)
+        offsets = [ref - m for m in meds]
+        captured["reference"] = background_reference
+        captured["offsets"] = offsets
+        return np.zeros(shape_out, dtype=np.float32), np.ones(shape_out, dtype=np.float32)
+
+    def dummy_wrapper(*args, **kwargs):
+        return dummy_reproject_and_coadd(list(zip(kwargs["data_list"], kwargs["wcs_list"])), kwargs.get("output_projection"), kwargs.get("shape_out"), match_background=kwargs.get("match_background", True), background_reference=kwargs.get("background_reference"))
+
+    monkeypatch.setattr(mosaic_utils, "reproject_and_coadd", dummy_reproject_and_coadd)
+    monkeypatch.setattr(mosaic_utils.zemosaic_utils, "reproject_and_coadd_wrapper", dummy_wrapper)
+
+    mosaic_utils.assemble_final_mosaic_with_reproject_coadd(paths, wcs, (10, 10), match_bg=True)
+
+    assert captured["reference"] == 1
+    assert np.allclose(captured["offsets"], [100, 0, -100])


### PR DESCRIPTION
## Summary
- add star detection and background metrics helpers
- automatically select best reference image for background matching
- log detailed background metrics for each tile
- expose `auto_bg_reference` and `force_reference_index`
- test automatic background reference selection

## Testing
- `pytest tests/test_auto_bg_reference.py::test_auto_background_reference -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68762549be0c832f83d7f17c57e75281