### PR TITLE
Set default final combine to Reproject & Coadd

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -654,7 +654,8 @@ class SeestarStackerGUI:
             f"DEBUG (GUI init_variables): Variable use_third_party_solver_var créée (valeur initiale: {self.use_third_party_solver_var.get()})."
         )
         self.reproject_between_batches_var = tk.BooleanVar(value=False)
-        self.reproject_coadd_var = tk.BooleanVar(value=False)
+        # Default final combine selection is "Reproject & Coadd"
+        self.reproject_coadd_var = tk.BooleanVar(value=True)
         self.ansvr_host_port_var = tk.StringVar(value="127.0.0.1:8080")
 
         self.astrometry_solve_field_dir_var = tk.StringVar(value="")

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -1328,7 +1328,8 @@ class SettingsManager:
         # When enabled, each batch is solved and reprojected incrementally onto
         # the reference WCS.
         defaults_dict["reproject_between_batches"] = False
-        defaults_dict["reproject_coadd_final"] = False
+        # Default to "Reproject & Coadd" for the final combine option
+        defaults_dict["reproject_coadd_final"] = True
 
         defaults_dict["mosaic_mode_active"] = False
         defaults_dict["mosaic_settings"] = {


### PR DESCRIPTION
## Summary
- default GUI final combine to 'Reproject & Coadd'
- update default in settings

## Testing
- `pytest tests -q`
- `PYTHONPATH=seestar/beforehand pytest seestar/beforehand/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a11d44f0832fbb955b98d9360bc5