### PR TITLE
Enable single-batch stacking from order CSV

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -8,6 +8,7 @@ import gc
 import logging
 import math
 import os
+import csv
 import platform  # NOUVEL import
 import subprocess  # NOUVEL import
 
@@ -6532,6 +6533,92 @@ class SeestarStackerGUI:
 
     # --- DANS LA CLASSE SeestarStackerGUI DANS seestar/gui/main_window.py ---
 
+    def _prepare_single_batch_if_needed(self) -> bool:
+        """Check for zenalakyser CSV when ``batch_size`` equals 1.
+
+        If a ``zenalakyser_order.csv`` file is found, the listed images are
+        queued in that order and parameters are forced so the entire sequence is
+        stacked as one batch using winsorized–sigma clipping. Missing CSV
+        simply falls back to the standard multi-batch behaviour.
+        """
+
+        if getattr(self.settings, "batch_size", 0) != 1:
+            return False
+
+        csv_path = getattr(self.settings, "order_csv_path", "") or os.path.join(
+            self.settings.input_folder, "zenalakyser_order.csv"
+        )
+
+        if not os.path.isfile(csv_path):
+            self.logger.warning(
+                "Batch size 1 without CSV – reverting to normal behaviour"
+            )
+            return False
+
+        self.logger.info(
+            f"Zenalakyser CSV detected at '{csv_path}'. Preparing single batch"
+        )
+
+        ordered_files: list[str] = []
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if not row:
+                    continue
+                fp = row[0].strip()
+                if not fp:
+                    continue
+                if not os.path.isabs(fp):
+                    fp = os.path.join(self.settings.input_folder, fp)
+                ordered_files.append(os.path.abspath(fp))
+
+        missing = [p for p in ordered_files if not os.path.isfile(p)]
+        if missing:
+            raise FileNotFoundError(missing[0])
+
+        if self.settings.stacking_mode != "winsorized-sigma":
+            self.logger.info("stacking_mode -> winsorized-sigma")
+        self.settings.stacking_mode = "winsorized-sigma"
+
+        if getattr(self.settings, "reproject_between_batches", False):
+            self.logger.info("reproject_between_batches -> False")
+        self.settings.reproject_between_batches = False
+
+        if getattr(self.settings, "use_drizzle", False):
+            self.logger.info("use_drizzle -> False")
+        self.settings.use_drizzle = False
+
+        self.settings.batch_size = len(ordered_files)
+        self.logger.info(f"batch_size -> {self.settings.batch_size}")
+
+        from queue import Queue
+
+        self.queued_stacker.queue = Queue()
+        self.queued_stacker.processed_files = set()
+        self.queued_stacker.files_in_queue = 0
+        self.queued_stacker.all_input_filepaths = []
+
+        for fp in ordered_files:
+            self.queued_stacker.queue.put(fp)
+            self.queued_stacker.processed_files.add(fp)
+            self.queued_stacker.files_in_queue += 1
+            self.queued_stacker.all_input_filepaths.append(fp)
+
+        self.queued_stacker.batch_size = self.settings.batch_size
+        if hasattr(self.queued_stacker, "_recalculate_total_batches"):
+            self.queued_stacker._recalculate_total_batches()
+        else:
+            import math
+
+            if self.settings.batch_size > 0:
+                self.queued_stacker.total_batches_estimated = math.ceil(
+                    self.queued_stacker.files_in_queue / self.settings.batch_size
+                )
+            else:
+                self.queued_stacker.total_batches_estimated = 0
+
+        return True
+
     def start_processing(self):
         """
         Démarre le traitement. Ordre crucial pour la gestion des paramètres :
@@ -6650,6 +6737,13 @@ class SeestarStackerGUI:
         print(
             "DEBUG (GUI start_processing): Phase 2 - Vérification avertissement OK (ou non applicable)."
         )
+
+        special_single = self._prepare_single_batch_if_needed()
+        if special_single:
+            self.batch_size.set(self.settings.batch_size)
+            self.stacking_mode.set(self.settings.stacking_mode)
+            self.reproject_between_batches_var.set(self.settings.reproject_between_batches)
+            self.use_drizzle_var.set(self.settings.use_drizzle)
 
         # --- Additional check: reproject modes require a configured local solver ---
         if (

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -1220,6 +1220,7 @@ class SettingsManager:
         defaults_dict["temp_folder"] = ""
         defaults_dict["bayer_pattern"] = "GRBG"
         defaults_dict["batch_size"] = 0
+        defaults_dict["order_csv_path"] = ""
         defaults_dict["stacking_mode"] = "kappa-sigma"
         defaults_dict["kappa"] = 2.5
         defaults_dict["stack_norm_method"] = "none"
@@ -2455,6 +2456,7 @@ class SettingsManager:
             "max_hq_mem_gb": float(self.max_hq_mem_gb),
             "stack_method": str(self.stack_method),
             "batch_size": int(self.batch_size),
+            "order_csv_path": str(getattr(self, "order_csv_path", "")),
             "correct_hot_pixels": bool(self.correct_hot_pixels),
             "hot_pixel_threshold": float(self.hot_pixel_threshold),
             "neighborhood_size": int(self.neighborhood_size),

--- a/tests/test_single_batch_csv.py
+++ b/tests/test_single_batch_csv.py
@@ -1,0 +1,58 @@
+import logging
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub GUI modules to avoid Tk dependence during import
+if "seestar.gui" not in sys.modules:
+    seestar_pkg = types.ModuleType("seestar")
+    seestar_pkg.__path__ = [str(ROOT / "seestar")]
+    gui_pkg = types.ModuleType("seestar.gui")
+    gui_pkg.__path__ = [str(ROOT / "seestar" / "gui")]
+    settings_mod = types.ModuleType("seestar.gui.settings")
+    settings_mod.SettingsManager = object
+    hist_mod = types.ModuleType("seestar.gui.histogram_widget")
+    hist_mod.HistogramWidget = object
+    gui_pkg.settings = settings_mod
+    gui_pkg.histogram_widget = hist_mod
+    seestar_pkg.gui = gui_pkg
+    sys.modules["seestar"] = seestar_pkg
+    sys.modules["seestar.gui"] = gui_pkg
+    sys.modules["seestar.gui.settings"] = settings_mod
+    sys.modules["seestar.gui.histogram_widget"] = hist_mod
+
+from seestar.gui.main_window import SeestarStackerGUI
+from seestar.queuep.queue_manager import SeestarQueuedStacker
+
+
+def test_single_batch_csv(tmp_path):
+    # create dummy images
+    files = []
+    for i in range(3):
+        fp = tmp_path / f"img{i}.fits"
+        fp.write_text("dummy")
+        files.append(fp)
+
+    csv_path = tmp_path / "zenalakyser_order.csv"
+    csv_path.write_text("\n".join(f.name for f in files))
+
+    gui = SeestarStackerGUI.__new__(SeestarStackerGUI)
+    gui.logger = logging.getLogger("test")
+    gui.settings = types.SimpleNamespace(
+        input_folder=str(tmp_path),
+        batch_size=1,
+        stacking_mode="kappa-sigma",
+        reproject_between_batches=True,
+        use_drizzle=True,
+        order_csv_path="",
+    )
+    gui.queued_stacker = SeestarQueuedStacker()
+
+    activated = SeestarStackerGUI._prepare_single_batch_if_needed(gui)
+    assert activated
+    assert gui.settings.stacking_mode == "winsorized-sigma"
+    assert gui.settings.batch_size == 3
+    assert gui.queued_stacker.total_batches_estimated == 1


### PR DESCRIPTION
## Summary
- allow optional `order_csv_path` setting
- add `_prepare_single_batch_if_needed` helper to load `zenalakyser_order.csv`
- call the helper at the start of processing
- unit test single batch CSV handling

## Testing
- `pytest -q tests/test_single_batch_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_6878d8536c14832fb2b98564525f5336