### PR TITLE
Enable single-batch stacking from order CSV

### DIFF
--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -1220,6 +1220,7 @@ class SettingsManager:
         defaults_dict["temp_folder"] = ""
         defaults_dict["bayer_pattern"] = "GRBG"
         defaults_dict["batch_size"] = 0
+        defaults_dict["order_csv_path"] = ""
         defaults_dict["stacking_mode"] = "kappa-sigma"
         defaults_dict["kappa"] = 2.5
         defaults_dict["stack_norm_method"] = "none"
@@ -2455,6 +2456,7 @@ class SettingsManager:
             "max_hq_mem_gb": float(self.max_hq_mem_gb),
             "stack_method": str(self.stack_method),
             "batch_size": int(self.batch_size),
+            "order_csv_path": str(getattr(self, "order_csv_path", "")),
             "correct_hot_pixels": bool(self.correct_hot_pixels),
             "hot_pixel_threshold": float(self.hot_pixel_threshold),
             "neighborhood_size": int(self.neighborhood_size),

--- a/tests/test_single_batch_csv.py
+++ b/tests/test_single_batch_csv.py
@@ -1,0 +1,58 @@
+import logging
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub GUI modules to avoid Tk dependence during import
+if "seestar.gui" not in sys.modules:
+    seestar_pkg = types.ModuleType("seestar")
+    seestar_pkg.__path__ = [str(ROOT / "seestar")]
+    gui_pkg = types.ModuleType("seestar.gui")
+    gui_pkg.__path__ = [str(ROOT / "seestar" / "gui")]
+    settings_mod = types.ModuleType("seestar.gui.settings")
+    settings_mod.SettingsManager = object
+    hist_mod = types.ModuleType("seestar.gui.histogram_widget")
+    hist_mod.HistogramWidget = object
+    gui_pkg.settings = settings_mod
+    gui_pkg.histogram_widget = hist_mod
+    seestar_pkg.gui = gui_pkg
+    sys.modules["seestar"] = seestar_pkg
+    sys.modules["seestar.gui"] = gui_pkg
+    sys.modules["seestar.gui.settings"] = settings_mod
+    sys.modules["seestar.gui.histogram_widget"] = hist_mod
+
+from seestar.gui.main_window import SeestarStackerGUI
+from seestar.queuep.queue_manager import SeestarQueuedStacker
+
+
+def test_single_batch_csv(tmp_path):
+    # create dummy images
+    files = []
+    for i in range(3):
+        fp = tmp_path / f"img{i}.fits"
+        fp.write_text("dummy")
+        files.append(fp)
+
+    csv_path = tmp_path / "zenalakyser_order.csv"
+    csv_path.write_text("\n".join(f.name for f in files))
+
+    gui = SeestarStackerGUI.__new__(SeestarStackerGUI)
+    gui.logger = logging.getLogger("test")
+    gui.settings = types.SimpleNamespace(
+        input_folder=str(tmp_path),
+        batch_size=1,
+        stacking_mode="kappa-sigma",
+        reproject_between_batches=True,
+        use_drizzle=True,
+        order_csv_path="",
+    )
+    gui.queued_stacker = SeestarQueuedStacker()
+
+    activated = SeestarStackerGUI._prepare_single_batch_if_needed(gui)
+    assert activated
+    assert gui.settings.stacking_mode == "winsorized-sigma"
+    assert gui.settings.batch_size == 3
+    assert gui.queued_stacker.total_batches_estimated == 1


### PR DESCRIPTION
## Summary
- allow optional `order_csv_path` setting
- add `_prepare_single_batch_if_needed` helper to load `zenalakyser_order.csv`
- call the helper at the start of processing
- unit test single batch CSV handling
- accept batch size `1` directly from the GUI

## Testing
- `pytest -q tests/test_single_batch_csv.py`


------
https://chatgpt.com/codex/tasks/task_e_6878d8536c14832fb2b98564525f5336