### PR TITLE
Update single batch logic and allow size 0

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -1350,8 +1350,8 @@ class SeestarStackerGUI:
         self.batch_size_label.pack(side=tk.LEFT, padx=(0, 5))
         self.batch_spinbox = ttk.Spinbox(
             batch_frame,
-            from_=1,
-            to=500,
+            from_=0,
+            to=9999,
             increment=1,
             textvariable=self.batch_size,
             width=5,
@@ -6534,9 +6534,9 @@ class SeestarStackerGUI:
     # --- DANS LA CLASSE SeestarStackerGUI DANS seestar/gui/main_window.py ---
 
     def _prepare_single_batch_if_needed(self) -> bool:
-        """Check for zenalakyser CSV when ``batch_size`` equals 1.
+        """Check for stack_plan CSV when ``batch_size`` equals 1.
 
-        If a ``zenalakyser_order.csv`` file is found, the listed images are
+        If a ``stack_plan.csv`` file is found, the listed images are
         queued in that order and parameters are forced so the entire sequence is
         stacked as one batch using winsorized–sigma clipping. Missing CSV
         simply falls back to the standard multi-batch behaviour.
@@ -6546,7 +6546,7 @@ class SeestarStackerGUI:
             return False
 
         csv_path = getattr(self.settings, "order_csv_path", "") or os.path.join(
-            self.settings.input_folder, "zenalakyser_order.csv"
+            self.settings.input_folder, "stack_plan.csv"
         )
 
         if not os.path.isfile(csv_path):

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -11440,7 +11440,7 @@ class SeestarQueuedStacker:
                 estimated_size = estimate_batch_size(
                     sample_image_path=sample_img_path_for_bsize
                 )
-                self.batch_size = max(3, estimated_size)
+                self.batch_size = max(1, estimated_size)
                 self.update_progress(
                     f"✅ Taille lot auto estimée et appliquée: {self.batch_size}", None
                 )
@@ -11451,7 +11451,7 @@ class SeestarQueuedStacker:
                 )
                 self.batch_size = 10
         else:
-            self.batch_size = max(3, int(requested_batch_size))
+            self.batch_size = max(1, int(requested_batch_size))
         self.update_progress(
             f"ⓘ Taille de lot effective pour le traitement : {self.batch_size}"
         )

--- a/tests/test_single_batch_csv.py
+++ b/tests/test_single_batch_csv.py
@@ -36,7 +36,7 @@ def test_single_batch_csv(tmp_path):
         fp.write_text("dummy")
         files.append(fp)
 
-    csv_path = tmp_path / "zenalakyser_order.csv"
+    csv_path = tmp_path / "stack_plan.csv"
     csv_path.write_text("\n".join(f.name for f in files))
 
     gui = SeestarStackerGUI.__new__(SeestarStackerGUI)


### PR DESCRIPTION
## Summary
- allow the Batch Size spinbox to accept 0 and 1
- look for `stack_plan.csv` instead of `zenalakyser_order.csv`
- relax batch size minimum in the worker
- adjust test for the new CSV name

## Testing
- `pytest tests/test_single_batch_csv.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f049bf40832f98c727473d7d7356