### PR TITLE
Fix multiprocessing start method and memmap context

### DIFF
--- a/seestar/main.py
+++ b/seestar/main.py
@@ -410,10 +410,19 @@ def main():
 
 
 if __name__ == "__main__":
+    import multiprocessing as _mp
+    # Ensure a safe start method on Windows and frozen executables
+    try:
+        _mp.freeze_support()
+        _mp.set_start_method("spawn", force=True)
+    except RuntimeError:
+        # Start method was already set elsewhere
+        pass
     try:
         main()
-    except SystemExit: pass
-    except Exception as e_fatal: 
+    except SystemExit:
+        pass
+    except Exception as e_fatal:
         print(f"\n--- ERREUR FATALE NON INTERCEPTÉE ---"); print(f"Erreur critique dans main():"); print(f"Type: {type(e_fatal).__name__}"); print(f"Erreur: {e_fatal}")
         print("\n--- Traceback ---"); traceback.print_exc(); print("-" * 30)
         try: input("Appuyez sur Entrée pour quitter...")


### PR DESCRIPTION
## Summary
- ensure `freeze_support` and `spawn` start method when launching GUI
- use multiprocessing spawn context for drizzle and quality executors

## Testing
- `pip install rasterio`
- `PYTHONPATH=seestar/beforehand pytest tests seestar/beforehand/tests/test_bortle.py seestar/beforehand/tests/test_mosaic_path.py seestar/beforehand/tests/test_organize_log.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68791ed7a814832fab4409408abacb32