### PR TITLE
Fix single-batch CSV handling

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -11947,16 +11947,15 @@ class SeestarQueuedStacker:
             self.files_in_queue = 0
             self.all_input_filepaths = []
             self.processed_files = set()
-            for idx, fp in enumerate(ordered_files):
+            for fp in ordered_files:
                 abs_fp = os.path.abspath(fp)
                 self.queue.put(abs_fp)
-                if idx < len(ordered_files) - 1:
-                    self.queue.put(_BATCH_BREAK_TOKEN)
                 self.processed_files.add(abs_fp)
                 self.files_in_queue += 1
                 self.all_input_filepaths.append(abs_fp)
-            self.batch_size = 1
-            self.total_batches_estimated = len(ordered_files)
+            batch_len = len(ordered_files)
+            self.batch_size = batch_len if batch_len > 0 else 1
+            self.total_batches_estimated = 1
             self.update_progress(
                 f"📋 {self.files_in_queue} fichiers initiaux ajoutés depuis stack_plan.csv"
             )

--- a/tests/test_single_batch_csv.py
+++ b/tests/test_single_batch_csv.py
@@ -56,8 +56,8 @@ def test_single_batch_csv(tmp_path):
     activated = SeestarStackerGUI._prepare_single_batch_if_needed(gui)
     assert activated
     assert gui.settings.stacking_mode == "winsorized-sigma"
-    assert gui.settings.batch_size == 1
-    assert gui.queued_stacker.total_batches_estimated == 3
+    assert gui.settings.batch_size == len(files)
+    assert gui.queued_stacker.total_batches_estimated == 1
 
 
 def test_single_batch_csv_with_index(tmp_path):
@@ -87,8 +87,8 @@ def test_single_batch_csv_with_index(tmp_path):
 
     activated = SeestarStackerGUI._prepare_single_batch_if_needed(gui)
     assert activated
-    assert gui.settings.batch_size == 1
-    assert gui.queued_stacker.total_batches_estimated == 3
+    assert gui.settings.batch_size == len(files)
+    assert gui.queued_stacker.total_batches_estimated == 1
 
 
 def test_single_batch_csv_with_additional_columns(tmp_path):
@@ -123,5 +123,5 @@ def test_single_batch_csv_with_additional_columns(tmp_path):
 
     activated = SeestarStackerGUI._prepare_single_batch_if_needed(gui)
     assert activated
-    assert gui.settings.batch_size == 1
-    assert gui.queued_stacker.total_batches_estimated == 3
+    assert gui.settings.batch_size == len(files)
+    assert gui.queued_stacker.total_batches_estimated == 1


### PR DESCRIPTION
## Summary
- ensure `batch_size=1` stacks all files in a single batch
- update the queue manager's CSV logic
- update tests for single batch mode

## Testing
- `PYTHONPATH=. pytest -k single_batch_csv -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a55697b4c832f86d0a52fcb5f32fa