### PR TITLE
Fix Queue variable scoping

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -11922,7 +11922,6 @@ class SeestarQueuedStacker:
                 and self.batch_size == self.files_in_queue
                 and self.total_batches_estimated == 1
             ):
-                from queue import Queue
 
                 new_q = Queue()
                 for idx, fp in enumerate(list(self.all_input_filepaths)):


### PR DESCRIPTION
## Summary
- remove a leftover `from queue import Queue` inside `start_processing`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rasterio')*

------
https://chatgpt.com/codex/tasks/task_e_687a5a043668832fb992794c8161d3ac