### PR TITLE
Enable single-batch stacking with CSV

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6642,6 +6642,7 @@ class SeestarStackerGUI:
         # special CSV mode which will enqueue ``ordered_files`` itself.
         self.settings.batch_size = 1
         self.settings.order_csv_path = csv_path
+        self.settings.order_file_list = ordered_files
         self.logger.info("batch_size -> 1 (single batch via plan)")
 
         return True
@@ -7045,6 +7046,7 @@ class SeestarStackerGUI:
             "normalize_method": self.settings.stack_norm_method,
             "weighting_method": self.settings.stack_weight_method,
             "batch_size": self.settings.batch_size,
+            "ordered_files": getattr(self.settings, "order_file_list", None),
             "correct_hot_pixels": self.settings.correct_hot_pixels,
             "hot_pixel_threshold": self.settings.hot_pixel_threshold,
             "neighborhood_size": self.settings.neighborhood_size,

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -1221,6 +1221,7 @@ class SettingsManager:
         defaults_dict["bayer_pattern"] = "GRBG"
         defaults_dict["batch_size"] = 0
         defaults_dict["order_csv_path"] = ""
+        defaults_dict["order_file_list"] = []
         defaults_dict["stacking_mode"] = "kappa-sigma"
         defaults_dict["kappa"] = 2.5
         defaults_dict["stack_norm_method"] = "none"
@@ -2457,6 +2458,7 @@ class SettingsManager:
             "stack_method": str(self.stack_method),
             "batch_size": int(self.batch_size),
             "order_csv_path": str(getattr(self, "order_csv_path", "")),
+            "order_file_list": list(getattr(self, "order_file_list", [])),
             "correct_hot_pixels": bool(self.correct_hot_pixels),
             "hot_pixel_threshold": float(self.hot_pixel_threshold),
             "neighborhood_size": int(self.neighborhood_size),

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -11065,6 +11065,7 @@ class SeestarQueuedStacker:
         normalize_method="none",
         weighting_method="none",
         batch_size=10,
+        ordered_files=None,
         correct_hot_pixels=True,
         hot_pixel_threshold=3.0,
         neighborhood_size=5,
@@ -11940,8 +11941,9 @@ class SeestarQueuedStacker:
             self.queue_prepared = False
         elif special_single_csv:
             self.use_batch_plan = True
-            batches_from_plan = get_batches_from_stack_plan(plan_path, self.current_folder)
-            ordered_files = [os.path.abspath(fp) for batch in batches_from_plan for fp in batch]
+            if ordered_files is None:
+                batches_from_plan = get_batches_from_stack_plan(plan_path, self.current_folder)
+                ordered_files = [os.path.abspath(fp) for batch in batches_from_plan for fp in batch]
             self.queue = Queue()
             self.files_in_queue = 0
             self.all_input_filepaths = []


### PR DESCRIPTION
## Summary
- add `order_file_list` setting for preloaded CSV paths
- pass ordered file list from GUI to queue manager
- queue manager respects provided list when stacking single batches

## Testing
- `pytest tests/test_single_batch_csv.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9883f548832f95744ce4e5136d26