### PR TITLE
Enable memmap for single-batch HQ combine

### DIFF
--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -11,6 +11,8 @@ import traceback
 
 import numpy as np
 
+TILE_HEIGHT = 512
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- store SettingsManager on queue manager instance
- expose TILE_HEIGHT constant
- allow `_combine_hq_by_tiles` to use disk-backed memmap when batch size is 1
- cleanup memmap after saving classic batches

## Testing
- `pytest -q tests`
- `PYTHONPATH=$PWD/seestar/beforehand:$PYTHONPATH pytest seestar/beforehand/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687b2fd7752c832fb6104ab05ca8e7a7