### PR TITLE
Disable preview when batch_size is 1

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6661,6 +6661,8 @@ class SeestarStackerGUI:
         8. Lancer le thread de traitement du backend.
         MODIFIED: Ajout d'un CRITICAL CHECK pour vérifier mosaic_settings avant l'envoi au backend.
         """
+        if self.settings.batch_size == 1:
+            self.settings.enable_preview = False
         print(
             "DEBUG (GUI start_processing): Début tentative démarrage du traitement..."
         )

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1956,6 +1956,9 @@ class SeestarQueuedStacker:
             "DEBUG QM [_update_preview_sum_w]: Tentative de mise à jour de l'aperçu SUM/W..."
         )
 
+        if hasattr(self, "settings") and not getattr(self.settings, "enable_preview", True):
+            return
+
         if self.preview_callback is None:
             logger.debug(
                 "DEBUG QM [_update_preview_sum_w]: Callback preview non défini. Sortie."


### PR DESCRIPTION
## Summary
- disable preview automatically if running in single-batch mode
- skip preview updates when previews are disabled

## Testing
- `pytest -q tests/test_quality_pool_size.py` *(fails: ImportError: cannot import name 'TILE_HEIGHT')*

------
https://chatgpt.com/codex/tasks/task_e_687c8c561ae4832f86be7f56bef9f31b