### PR TITLE
Fix grayscale preview saving

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -549,10 +549,10 @@ def main():
         fits_data.astype(np.float32),
         overwrite=True,
     )
-    imageio.imwrite(
-        os.path.join(args.out, "preview.png"),
-        np.clip(final, 0, 1) ** 0.5,
-    )
+    preview = np.clip(final, 0, 1) ** 0.5
+    if preview.ndim == 3 and preview.shape[2] == 1:
+        preview = preview[:, :, 0]
+    imageio.imwrite(os.path.join(args.out, "preview.png"), preview)
     flush_mmap(cum_sum)
     flush_mmap(cum_wht)
     del cum_sum


### PR DESCRIPTION
## Summary
- handle single-channel data when writing preview image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d58a9c23c832f9d47b031f5478c63