### PR TITLE
Fix preview PNG save

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -550,6 +550,7 @@ def main():
         overwrite=True,
     )
     preview = np.clip(final, 0, 1) ** 0.5
+    preview = np.clip(preview * 255, 0, 255).astype(np.uint8)
     if preview.ndim == 3 and preview.shape[2] == 1:
         preview = preview[:, :, 0]
     imageio.imwrite(os.path.join(args.out, "preview.png"), preview)


### PR DESCRIPTION
## Summary
- prevent crash when saving preview PNG by converting float data to 8-bit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5cc33dec832f9d90f81523656144