### PR TITLE
Rétablit modes de pondération manquants

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -1230,7 +1230,7 @@ class SeestarStackerGUI:
             )
         )
 
-        self.weight_keys = ["none", "snr", "stars"]
+        self.weight_keys = ["none", "noise_variance", "noise_fwhm", "snr", "stars"]
         self.weight_key_to_label = {}
         self.weight_label_to_key = {}
         for k in self.weight_keys:

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -1515,7 +1515,7 @@ class SettingsManager:
                 )
                 self.stack_norm_method = defaults_fallback["stack_norm_method"]
 
-            valid_weight_methods = ["none", "snr", "stars"]
+            valid_weight_methods = ["none", "noise_variance", "noise_fwhm", "snr", "stars"]
             self.stack_weight_method = str(
                 getattr(
                     self,

--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -55,6 +55,8 @@ EN_TRANSLATIONS = {
     "weight_method_none": "None",
     "weight_method_snr": "SNR",
     "weight_method_stars": "Stars",
+    "weight_method_noise_variance": "Noise Variance (1/σ²)",
+    "weight_method_noise_fwhm": "Noise + FWHM",
     "reject_algo_kappa_sigma": "Kappa-Sigma Clip",
     "reject_algo_winsorized_sigma_clip": "Winsorized Sigma Clip",
     "reject_algo_linear_fit_clip": "Linear Fit Clip",

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -55,6 +55,8 @@ FR_TRANSLATIONS = {
     "weight_method_none": "Aucune",
     "weight_method_snr": "SNR",
     "weight_method_stars": "Étoiles",
+    "weight_method_noise_variance": "Variance Bruit (1/σ²)",
+    "weight_method_noise_fwhm": "Bruit + FWHM",
     "reject_algo_kappa_sigma": "Kappa-Sigma Clip",
     "reject_algo_winsorized_sigma_clip": "Winsorized Sigma Clip",
     "reject_algo_linear_fit_clip": "Linear Fit Clip",


### PR DESCRIPTION
## Summary
- expose à nouveau `noise_variance` et `noise_fwhm` dans la liste des modes de pondération
- accepte ces valeurs dans `SettingsManager`
- ajoute les traductions FR/EN correspondantes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e367b2ad0832fb857462a37cabfbd