### PR TITLE
Fix single batch CSV lookup

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6818,14 +6818,23 @@ class SeestarStackerGUI:
         if getattr(self.settings, "batch_size", 0) != 1:
             return False
 
-        csv_path = getattr(self.settings, "order_csv_path", "") or os.path.join(
-            self.settings.input_folder, "stack_plan.csv"
-        )
+        explicit_path = getattr(self.settings, "order_csv_path", "")
+        default_path = os.path.join(self.settings.input_folder, "stack_plan.csv")
 
-        if not os.path.isfile(csv_path):
+        candidate_paths = [p for p in (explicit_path, default_path) if p]
+        csv_path = None
+        for p in candidate_paths:
+            if os.path.isfile(p):
+                csv_path = p
+                break
+
+        if csv_path is None:
             self.logger.warning(
                 "Batch size 1 without CSV – reverting to normal behaviour"
             )
+            self.settings.batch_size = 0
+            self.settings.order_csv_path = ""
+            self.settings.order_file_list = []
             return False
 
         self.logger.info(

--- a/tests/test_single_batch_csv.py
+++ b/tests/test_single_batch_csv.py
@@ -125,3 +125,24 @@ def test_single_batch_csv_with_additional_columns(tmp_path):
     assert activated
     assert gui.settings.batch_size == 1
     assert gui.settings.order_csv_path == str(csv_path)
+
+
+def test_single_batch_csv_missing_file(tmp_path):
+    """When batch_size==1 but no CSV exists, batch_size should reset to 0."""
+
+    gui = SeestarStackerGUI.__new__(SeestarStackerGUI)
+    gui.logger = logging.getLogger("test")
+    gui.settings = types.SimpleNamespace(
+        input_folder=str(tmp_path),
+        batch_size=1,
+        stacking_mode="kappa-sigma",
+        reproject_between_batches=True,
+        use_drizzle=True,
+        order_csv_path="",
+    )
+    gui.queued_stacker = SeestarQueuedStacker()
+
+    activated = SeestarStackerGUI._prepare_single_batch_if_needed(gui)
+    assert not activated
+    assert gui.settings.batch_size == 0
+    assert gui.settings.order_csv_path == ""


### PR DESCRIPTION
## Summary
- handle old `order_csv_path` entries when switching folders
- reset batch size to 0 when no CSV is found
- test behaviour when CSV missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e41a7a814832f957da680f663577f