### PR TITLE
Fix stack_plan lookup

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6818,17 +6818,9 @@ class SeestarStackerGUI:
         if getattr(self.settings, "batch_size", 0) != 1:
             return False
 
-        explicit_path = getattr(self.settings, "order_csv_path", "")
-        default_path = os.path.join(self.settings.input_folder, "stack_plan.csv")
+        csv_path = os.path.join(self.settings.input_folder, "stack_plan.csv")
 
-        candidate_paths = [p for p in (explicit_path, default_path) if p]
-        csv_path = None
-        for p in candidate_paths:
-            if os.path.isfile(p):
-                csv_path = p
-                break
-
-        if csv_path is None:
+        if not os.path.isfile(csv_path):
             self.logger.warning(
                 "Batch size 1 without CSV – reverting to normal behaviour"
             )


### PR DESCRIPTION
## Summary
- always read `stack_plan.csv` from the selected input directory
- don't pick up older CSVs from other directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e487839f0832fac562f8596331d5b