### PR TITLE
Fix standalone execution of boring_stack

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -2,6 +2,10 @@ import argparse
 import csv
 import os
 import sys
+
+# When executed directly, ensure the package root is discoverable.
+if __package__ in (None, ""):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 import gc
 import ctypes
 import logging


### PR DESCRIPTION
## Summary
- allow running `boring_stack.py` directly by adding project root to `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e922dfbb0832fac2c2e11a04d2bd3