### PR TITLE
Fix console Unicode handling

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -3,6 +3,14 @@ import csv
 import os
 import sys
 
+# Ensure console encoding supports UTF-8 characters (e.g. emojis)
+try:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
 # When executed directly, ensure the package root is discoverable.
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))


### PR DESCRIPTION
## Summary
- ensure UTF-8 console encoding when running `boring_stack.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e95063578832f92121e2bca16bc38