### PR TITLE
Fix _safe_print handling of closed stdout

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -58,7 +58,7 @@ def _safe_print(*args, **kwargs) -> None:
     """Print without raising if the output stream is closed."""
     try:
         print(*args, **kwargs)
-    except OSError:
+    except (OSError, ValueError):
         logger.debug("stdout/stderr unavailable", exc_info=True)
 
 


### PR DESCRIPTION
## Summary
- handle ValueError in `_safe_print`

## Testing
- `pytest -k test_auto_stretch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f26b84850832f97aeef2a0aa080d9