### PR TITLE
Fix Windows decoding of boring_stack output

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4370,6 +4370,8 @@ class SeestarStackerGUI:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 bufsize=1,
             )
 


### PR DESCRIPTION
## Summary
- avoid decoding errors when reading boring_stack output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f45a32340832f84e34cf5e3c7cc12