### PR TITLE
Disk-based stacking saves aligned images

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6255,6 +6255,10 @@ class SeestarStackerGUI:
                     "--batch-size",
                     "1",
                 ]
+                if self.settings.cleanup_temp:
+                    cmd.append("--cleanup-temp-files")
+                else:
+                    cmd.append("--no-cleanup-temp-files")
                 cmd.append("--no-solver")
                 threading.Thread(
                     target=self._run_boring_stack_process,


### PR DESCRIPTION
## Summary
- persist each aligned image into `_aligned_tmp`
- load aligned files in manageable batches for stacking
- optionally clean temporary directory based on GUI setting
- propagate GUI option to boring_stack CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f74b97568832fae5ba541cfbde08b