### PR TITLE
Fix local alignment initialization in boring_stack

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -793,12 +793,10 @@ def stream_stack(
     ref_img, _ = aligner._get_reference_image(
         input_folder, files_to_scan, tmp_output_dir
     )
-    if ref_img is not None:
-        aligner.reference_image_data = ref_img
-        _safe_print("✅ Image de référence chargée pour alignement local")
-    else:
-
-        aligner = SeestarAligner()
+    if ref_img is None:
+        raise RuntimeError("Aucune référence trouvée pour l'alignement local.")
+    aligner.reference_image_data = ref_img
+    _safe_print("✅ Image de référence chargée pour alignement local")
     if not rows:
         raise RuntimeError("CSV is empty")
 
@@ -950,6 +948,14 @@ def stream_stack(
         # Release the aligned image to keep memory usage low
         del img
         gc.collect()
+
+        if progress_callback:
+            try:
+                msg = f"Aligné {idx + 1}/{len(rows)}"
+                pct = 100.0 * (idx + 1) / len(rows)
+                progress_callback(msg, pct)
+            except Exception:
+                pass
 
     out_sum = os.path.abspath(str(out_sum)).strip()
     out_wht = os.path.abspath(str(out_wht)).strip()

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6091,7 +6091,20 @@ class SeestarStackerGUI:
             self._update_low_wht_mask_options_state()  # S'assurer d'appeler ceci aussi
         print("DEBUG (GUI start_processing): Phase 4 - Settings synchronisés et validés.")
 
-        special_single = self._prepare_single_batch_if_needed()
+        try:
+            special_single = self._prepare_single_batch_if_needed()
+        except FileNotFoundError as fnfe:
+            messagebox.showerror(
+                self.tr("error"),
+                self.tr(
+                    "stack_plan_missing_file_error",
+                    default="File listed in stack_plan.csv not found:\n{path}",
+                ).format(path=str(fnfe)),
+            )
+            if hasattr(self, "start_button") and self.start_button.winfo_exists():
+                self.start_button.config(state=tk.NORMAL)
+            print(f"DEBUG (GUI start_processing): Missing file in stack_plan - {fnfe}")
+            return
         if special_single:
             self.batch_size.set(self.settings.batch_size)
             self.stacking_mode.set(self.settings.stacking_mode)

--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -392,5 +392,6 @@ EN_TRANSLATIONS = {
     "use_best_reference_button": "Use Recommended Reference",
     "status_label": "Status:",
     "apply_snr_rejection": "Apply SNR Rejection",
+    "stack_plan_missing_file_error": "File listed in stack_plan.csv not found:\n{path}",
 }
 # --- END OF FILE seestar/localization/en.py ---

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -391,5 +391,6 @@ FR_TRANSLATIONS = {
         "- L'aperçu en direct montrera un stack classique ; le Drizzle sera appliqué à la toute fin.\n\n",
         "Continuer avec Drizzle ?",
     ),
+    "stack_plan_missing_file_error": "Fichier indique dans stack_plan.csv introuvable :\n{path}",
 }
 # --- END OF FILE seestar/localization/fr.py ---


### PR DESCRIPTION
## Summary
- prevent stream_stack from continuing without a reference image
- show progress after each aligned frame
- handle missing files in stack_plan.csv gracefully

## Testing
- `pytest -k boring_stack -q`


------
https://chatgpt.com/codex/tasks/task_e_687fb98627ac832fa29149a9ef1cbb16