### PR TITLE
Handle failed local alignment in stream_stack

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -906,8 +906,9 @@ def stream_stack(
 
                     img, ref_img, os.path.basename(row["path"])
                 )
-            if not ok:
+            if not ok or aligned_img is None:
                 _safe_print(f"⚠️ Alignement échoué pour {row['path']}")
+                aligned_img = img
             img = aligned_img
         else:
             img = open_aligned_slice(


### PR DESCRIPTION
## Summary
- handle `None` returned by `_align_image` inside `stream_stack`
- keep original image when alignment fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688002b8a218832fa64991939bb02e94