### PR TITLE
Fix batch-1 alignment workflow

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -810,7 +810,6 @@ def stream_stack(
     aligner.correct_hot_pixels = correct_hot_pixels
     aligner.hot_pixel_threshold = hot_threshold
     aligner.neighborhood_size = hot_neighborhood
-    local_align_only = batch_size == 1 and not use_solver
     out_dir = os.path.dirname(os.path.abspath(out_sum))
     unaligned_dir = os.path.join(out_dir, "unaligned_files")
     input_folder = os.path.dirname(rows[0]["path"])
@@ -911,32 +910,15 @@ def stream_stack(
     ref_low = ref_high = None
     ref_sky = None
     for idx, row in enumerate(rows):
-        if local_align_only:
-            img, _ = _read_image(row["path"])
-            if ref_basename and os.path.basename(row["path"]) == ref_basename:
-                aligned_img = ref_img.astype(np.float32)
-                ok = True
-            else:
-                aligned_img, _, ok = aligner._align_image(
-                    img, ref_img, os.path.basename(row["path"])
-                )
-            if not ok or aligned_img is None:
-                _safe_print(f"⚠️ Alignement échoué pour {row['path']}")
-                _move_unaligned_file(row["path"], unaligned_dir, idx)
-                del img
-                gc.collect()
-                continue
-            img = aligned_img
-        else:
-            img = open_aligned_slice(
-                row["path"],
-                0,
-                H,
-                wcs_cache[row["path"]],
-                wcs_ref,
-                shape_ref,
-                use_solver=use_solver,
-            )
+        img = open_aligned_slice(
+            row["path"],
+            0,
+            H,
+            wcs_cache.get(row["path"]),
+            wcs_ref,
+            shape_ref,
+            use_solver=use_solver,
+        )
         if correct_hot_pixels:
             try:
                 from seestar.core.hot_pixels import detect_and_correct_hot_pixels


### PR DESCRIPTION
## Summary
- revert `open_aligned_slice` to batch‑0 behavior
- remove leftover `local_align_only` variable
- use `open_aligned_slice` for every image when stacking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800ce90da4832fb8ed6b59af42ca07