### PR TITLE
Ensure local aligner runs without solver flag

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -434,32 +434,32 @@ def open_aligned_slice(path, y0, y1, wcs, wcs_ref, shape_ref, *, use_solver=True
         data = cv2.cvtColor(data, cv2.COLOR_BGR2RGB).astype(np.float32)
 
 
-    if use_solver:
-        try:
-            global aligner
-            ok = False
-            if (
-                aligner
-                and hasattr(aligner, "reference_image_data")
-                and aligner.reference_image_data is not None
-            ):
-                aligned, _, ok = aligner._align_image(
-                    data, aligner.reference_image_data, os.path.basename(path)
-                )
-                if ok:
-                    data = aligned
-            if not ok and wcs is not None and wcs_ref is not None:
+    try:
+        global aligner
+        ok = False
+        if (
+            aligner
+            and hasattr(aligner, "reference_image_data")
+            and aligner.reference_image_data is not None
+        ):
+            aligned, _, ok = aligner._align_image(
+                data, aligner.reference_image_data, os.path.basename(path)
+            )
+            if ok:
+                data = aligned
 
-                try:
-                    data = warp_image(data, wcs, wcs_ref, shape_ref)
-                    ok = True
-                except Exception as e:
-                    logger.warning("WCS align failed for %s: %s", path, e)
-            if not ok:
-                _safe_print(f"⚠️ Alignement échoué pour {path}")
+        if not ok and use_solver and wcs is not None and wcs_ref is not None:
+            try:
+                data = warp_image(data, wcs, wcs_ref, shape_ref)
+                ok = True
+            except Exception as e:
+                logger.warning("WCS align failed for %s: %s", path, e)
 
-        except Exception as e:
-            _safe_print(f"❌ Erreur alignement local: {e}")
+        if not ok:
+            _safe_print(f"⚠️ Alignement échoué pour {path}")
+
+    except Exception as e:
+        _safe_print(f"❌ Erreur alignement local: {e}")
 
 
     slice_data = data[y0:y1].copy()


### PR DESCRIPTION
## Summary
- always attempt local FastSeestarAligner before optional WCS alignment
- fall back to WCS only when solver flag is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880821b56ec832f94de636a12d517d4