### PR TITLE
Fix boring_stack logging format

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -146,9 +146,13 @@ def main() -> int:
     os.makedirs(args.out, exist_ok=True)
     logging.basicConfig(
         level=logging.DEBUG,
-        format="%(asctime)s | %(levelname)s | %(message)s",
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         handlers=[
-            logging.FileHandler(os.path.join(args.out, "boring_stack.log"), mode="w", encoding="utf-8"),
+            logging.FileHandler(
+                os.path.join(args.out, "boring_stack.log"),
+                mode="w",
+                encoding="utf-8",
+            ),
             logging.StreamHandler(sys.stdout),
         ],
     )


### PR DESCRIPTION
## Summary
- match console log format for boring_stack with GUI's format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b9640d5c832f80dcfd2e0ab86e3d