### PR TITLE
Fix batch-1 CLI stack

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -171,6 +171,10 @@ def main() -> int:
     # the GUI's batch-size-1 handling ("mode 0").
     input_dir = os.path.dirname(os.path.abspath(args.csv))
 
+    # ``tile`` is ignored by ``SeestarQueuedStacker`` but remains configurable
+    # via ``SEESTAR_TILE_H`` to aid debugging memory usage.
+    os.environ["SEESTAR_TILE_H"] = str(args.tile)
+
     stacker = SeestarQueuedStacker()
     ok = stacker.start_processing(
         input_dir=input_dir,


### PR DESCRIPTION
## Summary
- ensure `SEESTAR_TILE_H` is set when using `boring_stack.py`

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_single_batch_csv.py::test_single_batch_csv -q` *(fails: ImportError cannot import name 'TILE_HEIGHT' from 'seestar.gui.settings')*

------
https://chatgpt.com/codex/tasks/task_e_6880c272f75c832fa3b7033b5e03fd5d