### PR TITLE
Fix direct execution of boring_stack

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -174,7 +174,11 @@ import numpy.lib.format as _np_format
 _np_format.open_memmap = _safe_open_memmap
 
 from seestar.queuep.queue_manager import SeestarQueuedStacker
-from ..core.image_processing import load_and_validate_fits, save_fits_image
+# Import helpers from the core package.  Use an absolute import so that this
+# script can be executed directly without Python considering it a package
+# relative module.  When ``__package__`` is ``None`` the project root is added
+# to ``sys.path`` above, allowing this import to succeed.
+from seestar.core.image_processing import load_and_validate_fits, save_fits_image
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- allow `seestar/gui/boring_stack.py` to be run as a standalone script by using an absolute import

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e7dc3c34832fb45d9e334c44d5c2