### PR TITLE
Fix path mis-ordered in boring_stack save

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -336,7 +336,7 @@ def main() -> int:
             chunk_size=chunk,
         )
 
-        save_fits_image(out_path, stacked, header=hdr_ref)
+        save_fits_image(stacked, out_path, header=hdr_ref)
         return
 
     def log_progress(message: str, progress: object | None = None) -> None:


### PR DESCRIPTION
## Summary
- fix argument order when saving the final stack in `boring_stack.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ebbaf12c832f9277833567c5121d