### PR TITLE
Fix memory cleanup for boring stacker

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -270,6 +270,9 @@ def main() -> int:
 
         while stacker.is_running():
             time.sleep(1)
+            if args.batch_size == 1:
+                getattr(stacker, "_indices_cache", {}).clear()
+                gc.collect()
 
         final_path = getattr(stacker, "final_stacked_path", None)
         if final_path and os.path.isfile(final_path):


### PR DESCRIPTION
## Summary
- revert queue manager modification
- clear `_indices_cache` each poll when batch_size is 1 in `boring_stack.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688101e4538c832fa59e9a75cbdaaef2