### PR TITLE
Add chunk size for incremental batch-1 stacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,18 @@ initial WCS is reused for every batch. Subsequent batches are reprojected using
 a new fixed-orientation grid so the image orientation stays constant and small
 rotation drifts are eliminated.
 
+### Command-Line Stacking
+
+Use `seestar/gui/boring_stack.py` for headless single-batch processing. Set
+`--chunk-size` to periodically flush intermediate stacks:
+
+```bash
+python seestar/gui/boring_stack.py --csv stack_plan.csv --out OUT_DIR \
+    --batch-size 1 --chunk-size 50
+```
+
+When `--chunk-size` is used with `--batch-size 1`, results are combined in
+chunks of N images so incremental stacking works without a `stack_plan.csv`.
 
 ---
 

--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -172,6 +172,14 @@ def parse_args():
     p.add_argument("--max-mem", type=float, default=None, help="(unused)")
     p.add_argument("--api-key", default=None, help="Astrometry.net API key")
     p.add_argument("--batch-size", type=int, default=1, help="Batch size")
+    p.add_argument(
+        "--chunk-size",
+        type=int,
+        default=None,
+        help=(
+            "Flush intermediate results every N images when batch size is 1"
+        ),
+    )
     p.add_argument("--norm", default="none", choices=["linear_fit", "sky_mean", "none"], help="Normalization")
     p.add_argument(
         "--weight",
@@ -259,6 +267,7 @@ def main() -> int:
             normalize_method=args.norm,
             weighting_method=args.weight,
             batch_size=args.batch_size,
+            chunk_size=args.chunk_size,
             ordered_files=ordered_files,
             correct_hot_pixels=args.correct_hot_pixels,
             hot_pixel_threshold=args.hot_threshold,

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3883,9 +3883,14 @@ class SeestarQueuedStacker:
                                 )
                                 self._current_batch_paths.append(file_path)
 
+                                trigger = (
+                                    getattr(self, "chunk_size", None)
+                                    if self.batch_size == 1 and getattr(self, "chunk_size", None)
+                                    else self.batch_size
+                                )
                                 if (
                                     len(current_batch_items_with_masks_for_stack_batch)
-                                    >= self.batch_size
+                                    >= trigger
                                 ):
                                     self.stacked_batches_count += 1
                                     num_in_batch = len(
@@ -4052,9 +4057,14 @@ class SeestarQueuedStacker:
                                     )
                                     self._current_batch_paths.append(file_path)
 
+                                trigger = (
+                                    getattr(self, "chunk_size", None)
+                                    if self.batch_size == 1 and getattr(self, "chunk_size", None)
+                                    else self.batch_size
+                                )
                                 if (
                                     len(current_batch_items_with_masks_for_stack_batch)
-                                    >= self.batch_size
+                                    >= trigger
                                 ):
                                     self.stacked_batches_count += 1
                                     self._send_eta_update()
@@ -11475,6 +11485,7 @@ class SeestarQueuedStacker:
         preserve_linear_output=False,
         reproject_between_batches=None,
         reproject_coadd_final=None,
+        chunk_size=None,
     ):
         logger.debug(
             f"!!!!!!!!!! VALEUR BRUTE ARGUMENT astap_search_radius REÇU : {astap_search_radius} !!!!!!!!!!"
@@ -11703,6 +11714,7 @@ class SeestarQueuedStacker:
 
         self.move_stacked = bool(move_stacked)
         self.partial_save_interval = max(1, int(partial_save_interval))
+        self.chunk_size = int(chunk_size) if chunk_size else None
 
         # --- NOUVEAU : Assignation du paramètre de sauvegarde à l'attribut de l'instance ---
 


### PR DESCRIPTION
## Summary
- add `--chunk-size` option to `boring_stack.py`
- support `chunk_size` in `SeestarQueuedStacker.start_processing`
- flush queued stack items when chunk size is reached
- document command line stacking with chunked batches in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811d8e915c832f9d7bbf15124949eb