### PR TITLE
Fix memory usage during normalization

### DIFF
--- a/seestar/core/normalization.py
+++ b/seestar/core/normalization.py
@@ -17,7 +17,7 @@ def _normalize_images_linear_fit(image_list, reference_index=0, low_percentile=2
         if img is None:
             normalized.append(None)
             continue
-        data = img.astype(np.float32, copy=True)
+        data = img.astype(np.float32, copy=False)
         if i == reference_index:
             normalized.append(data)
             continue
@@ -49,7 +49,7 @@ def _normalize_images_sky_mean(image_list, reference_index=0, sky_percentile=25.
         if img is None:
             normalized.append(None)
             continue
-        data = img.astype(np.float32, copy=True)
+        data = img.astype(np.float32, copy=False)
         if i == reference_index:
             normalized.append(data)
             continue


### PR DESCRIPTION
## Summary
- avoid unnecessary copies when converting images to float32 during normalization

## Testing
- `pytest tests/test_stack_plan_module.py::test_get_batches_from_stack_plan -q`

------
https://chatgpt.com/codex/tasks/task_e_688149e4c820832faa0edec07cf6f9fe