### PR TITLE
Enable disk-backed alignment mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,13 @@ initial WCS is reused for every batch. Subsequent batches are reprojected using
 a new fixed-orientation grid so the image orientation stays constant and small
 rotation drifts are eliminated.
 
+### Alignment Options
+
+The aligner normally keeps intermediate arrays in memory. For very large
+images you can reduce memory usage by performing alignment on disk-backed
+``.npy`` files. Pass ``align_on_disk=True`` when using ``SeestarQueuedStacker``
+from Python or add ``--align-on-disk`` to ``boring_stack.py``.
+
 ### Command-Line Stacking
 
 Use `seestar/gui/boring_stack.py` for headless single-batch processing. Set

--- a/seestar/core/alignment.py
+++ b/seestar/core/alignment.py
@@ -12,6 +12,7 @@ import warnings
 import logging
 import gc
 import shutil
+import tempfile
 import concurrent.futures
 import traceback # Added for traceback printing
 try: from tqdm import tqdm # Optionnel, pour la barre de progression console
@@ -69,20 +70,34 @@ class SeestarAligner:
             else:
                 print(message)
 
-    def _align_cpu(self, img: np.ndarray, M: np.ndarray, dsize: tuple[int, int]) -> np.ndarray:
+    def _align_cpu(
+        self,
+        img: np.ndarray,
+        M: np.ndarray,
+        dsize: tuple[int, int],
+        out: np.ndarray | None = None,
+    ) -> np.ndarray:
         """Apply affine transform using CPU."""
         if img.ndim == 3:
-            result = np.zeros((dsize[1], dsize[0], img.shape[2]), dtype=img.dtype)
+            result = out
+            if result is None:
+                result = np.zeros((dsize[1], dsize[0], img.shape[2]), dtype=img.dtype)
             for i in range(img.shape[2]):
-                result[:, :, i] = cv2.warpAffine(
-                    img[:, :, i], M, dsize,
+                cv2.warpAffine(
+                    img[:, :, i],
+                    M,
+                    dsize,
+                    dst=result[:, :, i],
                     flags=cv2.INTER_LINEAR,
                     borderMode=cv2.BORDER_CONSTANT,
                     borderValue=np.nan,
                 )
             return result
         return cv2.warpAffine(
-            img, M, dsize,
+            img,
+            M,
+            dsize,
+            dst=out,
             flags=cv2.INTER_LINEAR,
             borderMode=cv2.BORDER_CONSTANT,
             borderValue=np.nan,
@@ -120,7 +135,7 @@ class SeestarAligner:
 # --- DANS LA CLASSE SeestarAligner (dans seestar/core/alignment.py) ---
 # ... (imports et début de la méthode inchangés) ...
 
-    def _align_image(self, img_to_align, reference_image, file_name, force_same_shape_as_ref=True):
+    def _align_image(self, img_to_align, reference_image, file_name, force_same_shape_as_ref=True, use_disk=False):
         """
         Aligns a single image to the reference.
 
@@ -138,7 +153,23 @@ class SeestarAligner:
             print(f"    Input img_to_align: None. Retour échec.")
             return None, False 
         
-        img_to_align_for_transform_application = img_to_align.astype(np.float32, copy=True) 
+        tmp_in_path = None
+        if use_disk:
+            tmp_in_path = tempfile.mktemp(suffix=".npy")
+            img_to_align_for_transform_application = np.lib.format.open_memmap(
+                tmp_in_path,
+                mode="w+",
+                dtype=np.float32,
+                shape=img_to_align.shape,
+            )
+            img_to_align_for_transform_application[:] = img_to_align.astype(
+                np.float32, copy=False
+            )
+            img_to_align_for_transform_application.flush()
+        else:
+            img_to_align_for_transform_application = img_to_align.astype(
+                np.float32, copy=True
+            )
         original_min_in = np.nanmin(img_to_align_for_transform_application)
         original_max_in = np.nanmax(img_to_align_for_transform_application)
         input_was_likely_01 = (original_max_in < 1.5 and original_max_in > -0.2 and original_min_in > -0.2 and original_min_in < 1.1)
@@ -214,28 +245,73 @@ class SeestarAligner:
                 cv2_M_final = (shift_M @ cv2_M_3x3)[:2, :]
                 dsize_cv2 = (w_out, h_out)
 
-            align = self._align_cuda if getattr(self, "use_cuda", False) else self._align_cpu
+            align = self._align_cuda if (getattr(self, "use_cuda", False) and not use_disk) else self._align_cpu
             try:
-                aligned_img_final = align(img_to_align_for_transform_application, cv2_M_final, dsize_cv2)
+                if use_disk:
+                    tmp_out_path = tempfile.mktemp(suffix=".npy")
+                    out_mm = np.lib.format.open_memmap(
+                        tmp_out_path,
+                        mode="w+",
+                        dtype=np.float32,
+                        shape=(dsize_cv2[1], dsize_cv2[0], img_to_align_for_transform_application.shape[2])
+                        if img_to_align_for_transform_application.ndim == 3
+                        else (dsize_cv2[1], dsize_cv2[0]),
+                    )
+                    aligned_img_final = align(
+                        img_to_align_for_transform_application,
+                        cv2_M_final,
+                        dsize_cv2,
+                        out=out_mm,
+                    )
+                    out_mm.flush()
+                else:
+                    aligned_img_final = align(
+                        img_to_align_for_transform_application, cv2_M_final, dsize_cv2
+                    )
             except Exception as cuda_err:
                 if getattr(self, "use_cuda", False):
                     self.use_cuda = False
                     self.update_progress("⚠️ CUDA align failed, falling back to CPU", None)
-                    aligned_img_final = self._align_cpu(img_to_align_for_transform_application, cv2_M_final, dsize_cv2)
+                    if use_disk:
+                        aligned_img_final = self._align_cpu(
+                            img_to_align_for_transform_application,
+                            cv2_M_final,
+                            dsize_cv2,
+                            out=out_mm,
+                        )
+                        out_mm.flush()
+                    else:
+                        aligned_img_final = self._align_cpu(
+                            img_to_align_for_transform_application, cv2_M_final, dsize_cv2
+                        )
                 else:
                     raise
             
             print(f"    APRÈS cv2.warpAffine: aligned_img_final - Range: [{np.nanmin(aligned_img_final):.4g}, {np.nanmax(aligned_img_final):.4g}]")
 
-            aligned_img_final = np.nan_to_num(aligned_img_final.astype(np.float32, copy=False), nan=0.0)
+            if use_disk and isinstance(aligned_img_final, np.memmap):
+                aligned_img_final[:] = np.nan_to_num(aligned_img_final, copy=False, nan=0.0)
+            else:
+                aligned_img_final = np.nan_to_num(aligned_img_final.astype(np.float32, copy=False), nan=0.0)
             
             if input_was_likely_01:
-                aligned_img_final = np.clip(aligned_img_final, 0.0, 1.0)
+                if use_disk and isinstance(aligned_img_final, np.memmap):
+                    np.clip(aligned_img_final, 0.0, 1.0, out=aligned_img_final)
+                else:
+                    aligned_img_final = np.clip(aligned_img_final, 0.0, 1.0)
                 print(f"    Sortie finale pour entrée ~0-1 (après clip [0,1]): Range: [{np.min(aligned_img_final):.4g}, {np.max(aligned_img_final):.4g}]")
             else:
-                aligned_img_final = np.clip(aligned_img_final, 0.0, None)
+                if use_disk and isinstance(aligned_img_final, np.memmap):
+                    np.clip(aligned_img_final, 0.0, None, out=aligned_img_final)
+                else:
+                    aligned_img_final = np.clip(aligned_img_final, 0.0, None)
                 print(f"    Sortie finale pour entrée ADU (après clip >=0): Range: [{np.min(aligned_img_final):.4g}, {np.max(aligned_img_final):.4g}]")
 
+            if use_disk and tmp_in_path and os.path.exists(tmp_in_path):
+                try:
+                    os.remove(tmp_in_path)
+                except Exception:
+                    pass
             return aligned_img_final, True
 
         except aa.MaxIterError as ae:

--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -215,6 +215,7 @@ def parse_args():
     p.add_argument("--use-solver", dest="use_solver", action="store_true")
     p.add_argument("--no-solver", dest="use_solver", action="store_false")
     p.add_argument("--cleanup-temp-files", dest="cleanup_temp_files", action=argparse.BooleanOptionalAction, default=True)
+    p.add_argument("--align-on-disk", action="store_true", help="Use memmap files during alignment")
     p.set_defaults(use_solver=True)
     return p.parse_args()
 
@@ -270,7 +271,7 @@ def main() -> int:
             logger.info("%s (%s)", message, progress)
         _log_mem(f"progress:{message}")
 
-    stacker = SeestarQueuedStacker()
+    stacker = SeestarQueuedStacker(align_on_disk=args.align_on_disk)
     try:
         stacker.progress_callback = log_progress
         _log_mem("before_start")  # DEBUG: baseline RAM

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6135,6 +6135,12 @@ class SeestarStackerGUI:
             self.reproject_between_batches_var.set(self.settings.reproject_between_batches)
             self.use_drizzle_var.set(self.settings.use_drizzle)
 
+        # Automatically enable disk-backed alignment when batching
+        try:
+            self.queued_stacker.align_on_disk = int(self.settings.batch_size) >= 1
+        except Exception:
+            self.queued_stacker.align_on_disk = False
+
         # --- 5. Préparation des arguments pour le backend (inchangée, lit depuis self.settings) ---
         print(
             "DEBUG (GUI start_processing): Phase 5 - Préparation des arguments pour le backend depuis self.settings..."
@@ -6297,6 +6303,7 @@ class SeestarStackerGUI:
                 else:
                     cmd.append("--no-cleanup-temp-files")
                 cmd.append("--no-solver")
+                cmd.append("--align-on-disk")
                 threading.Thread(
                     target=self._run_boring_stack_process,
                     args=(cmd, csv_path, out_dir),


### PR DESCRIPTION
## Summary
- support optional memmap workflow in `SeestarAligner._align_image`
- implement `align_on_disk` flag in `SeestarQueuedStacker` and CLI
- persist memmap output in `_save_aligned_temp`
- document disk-based alignment option
- test memmap alignment path
- auto-enable disk-backed alignment in the GUI when batching

## Testing
- `pytest -q tests/test_single_batch_csv.py::test_align_on_disk_large_image -s`


------
https://chatgpt.com/codex/tasks/task_e_6881e71078b0832f921cb5ebde386be2