### PR TITLE
Fix memory cleanup for on-disk alignment

### DIFF
--- a/seestar/core/alignment.py
+++ b/seestar/core/alignment.py
@@ -309,11 +309,23 @@ class SeestarAligner:
                     aligned_img_final = np.clip(aligned_img_final, 0.0, None)
                 print(f"    Sortie finale pour entrée ADU (après clip >=0): Range: [{np.min(aligned_img_final):.4g}, {np.max(aligned_img_final):.4g}]")
 
-            if use_disk and tmp_in_path and os.path.exists(tmp_in_path):
-                try:
-                    os.remove(tmp_in_path)
-                except Exception:
-                    pass
+            if use_disk:
+                if isinstance(img_to_align_for_transform_application, np.memmap):
+                    try:
+                        img_to_align_for_transform_application.flush()
+                        if (
+                            hasattr(img_to_align_for_transform_application, "_mmap")
+                            and img_to_align_for_transform_application._mmap is not None
+                        ):
+                            img_to_align_for_transform_application._mmap.close()
+                    except Exception:
+                        pass
+                if tmp_in_path and os.path.exists(tmp_in_path):
+                    try:
+                        os.remove(tmp_in_path)
+                    except Exception:
+                        pass
+                gc.collect()
             return aligned_img_final, True
 
         except aa.MaxIterError as ae:


### PR DESCRIPTION
## Summary
- track open file count in memory logger
- close memmap files when saving aligned data
- aggressively free memmaps in `_process_file`
- log memory after each image processed
- add memory logging to streaming stack
- close temp memmaps in `_align_image`

## Testing
- `pytest -k streaming_stack -q`
- `pytest tests/test_single_batch_csv.py::test_single_batch_csv -q`


------
https://chatgpt.com/codex/tasks/task_e_68825252ec50832f9f2eb5b8042c3724