### PR TITLE
Add threaded boring stack GUI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Seestar Stacker est une application graphique conçue pour aligner et empiler de
     *   SNR-based weighting
     *   Star count/sharpness analysis
 *   **Memory Optimization:** Batch processing with auto RAM management
+*   **Threaded Boring Stack Mode:** Set **Batch Size** to `0` (or enable the
+    *Threaded Boring Stack* checkbox) to run `boring_stack.py` in a dedicated
+    worker thread for minimal memory usage.
 
 The Expert tab's **Output FITS Format** panel features a checkbox labeled
 **Preserve Linear Output**. Enabling it saves the stacked FITS directly from the
@@ -400,6 +403,12 @@ When `--chunk-size` is used with `--batch-size 1`, results are combined in
 chunks of N images so incremental stacking works without a `stack_plan.csv`.
 If a `stack_plan.csv` is present, it will be ignored unless `--chunk-size` is
 omitted.
+
+### Threaded Boring Stack from the GUI
+
+Set **Batch Size** to `0` or tick the *Threaded Boring Stack* checkbox in the
+Stacking tab. The GUI will launch `boring_stack.py` in a background thread using
+your `stack_plan.csv` and display progress as it runs.
 
 
 ---

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -338,6 +338,7 @@ class SeestarStackerGUI:
         if hasattr(self, "_update_spinbox_from_float"):
             self._update_spinbox_from_float()
         self._update_drizzle_options_state()
+        self._toggle_boring_thread()
         self._update_show_folders_button_state()
         self.update_ui_language()
 
@@ -485,6 +486,7 @@ class SeestarStackerGUI:
         self.stacking_winsor_limits_str_var = tk.StringVar(value="0.05,0.05")
         self.max_hq_mem_var = tk.DoubleVar(value=8)
         self.batch_size = tk.IntVar(value=10)
+        self.boring_thread_var = tk.BooleanVar(value=False)
         self.correct_hot_pixels = tk.BooleanVar(value=True)
         self.hot_pixel_threshold = tk.DoubleVar(value=3.0)
         self.neighborhood_size = tk.IntVar(value=5)
@@ -687,6 +689,19 @@ class SeestarStackerGUI:
         except Exception as e:
             print(f"ERREUR inattendue dans _update_final_scnr_options_state: {e}")
             traceback.print_exc(limit=1)
+
+    def _toggle_boring_thread(self):
+        """Set batch_size to 0 and disable its spinbox when boring mode is active."""
+        try:
+            if self.boring_thread_var.get():
+                self.batch_size.set(0)
+                if hasattr(self, "batch_spinbox") and self.batch_spinbox.winfo_exists():
+                    self.batch_spinbox.config(state=tk.DISABLED)
+            else:
+                if hasattr(self, "batch_spinbox") and self.batch_spinbox.winfo_exists():
+                    self.batch_spinbox.config(state=tk.NORMAL)
+        except tk.TclError:
+            pass
 
     # Assurez-vous d'appeler cette méthode aussi dans SettingsManager.apply_to_ui
     # et dans SeestarStackerGUI.__init__ après avoir appliqué les settings
@@ -1229,6 +1244,13 @@ class SeestarStackerGUI:
             width=5,
         )
         self.batch_spinbox.pack(side=tk.LEFT)
+        self.boring_thread_check = ttk.Checkbutton(
+            batch_frame,
+            text=self.tr("enable_boring_thread", default="Threaded Boring Stack"),
+            variable=self.boring_thread_var,
+            command=self._toggle_boring_thread,
+        )
+        self.boring_thread_check.pack(side=tk.LEFT, padx=5)
         self.drizzle_options_frame = ttk.LabelFrame(tab_stacking, text="Drizzle Options")
         self.drizzle_options_frame.pack(fill=tk.X, pady=5, padx=5)
         self.drizzle_check = ttk.Checkbutton(

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -619,6 +619,17 @@ class SettingsManager:
             )
             # --- FIN NOUVEAU ---
 
+            # --- NEW: read boring thread mode ---
+            self.boring_thread_mode = getattr(
+                gui_instance,
+                "boring_thread_var",
+                tk.BooleanVar(value=default_values_from_code.get("boring_thread_mode", False)),
+            ).get()
+            logger.debug(
+                f"DEBUG SM (update_from_ui): boring_thread_mode lu (attribut UI ou défaut): {self.boring_thread_mode}"
+            )
+            # --- END NEW ---
+
             self.mosaic_mode_active = bool(
                 getattr(
                     gui_instance,
@@ -1104,6 +1115,17 @@ class SettingsManager:
             )
             # --- FIN NOUVEAU ---
 
+            # --- NEW: Apply boring thread mode ---
+            getattr(gui_instance, "boring_thread_var", tk.BooleanVar()).set(
+                self.boring_thread_mode
+            )
+            if hasattr(gui_instance, "_toggle_boring_thread"):
+                gui_instance._toggle_boring_thread()
+            logger.debug(
+                f"DEBUG (Settings apply_to_ui): boring_thread_mode appliqué à l'UI (valeur: {self.boring_thread_mode})"
+            )
+            # --- END NEW ---
+
             getattr(gui_instance, "preview_stretch_method", tk.StringVar()).set(
                 self.preview_stretch_method
             )
@@ -1301,6 +1323,13 @@ class SettingsManager:
             f"DEBUG (SettingsManager get_default_values): Ajout de 'save_final_as_float32'={defaults_dict['save_final_as_float32']}"
         )
         # --- FIN NOUVEAU ---
+
+        # --- NEW: boring thread mode default ---
+        defaults_dict["boring_thread_mode"] = False
+        logger.debug(
+            f"DEBUG (SettingsManager get_default_values): Ajout de 'boring_thread_mode'={defaults_dict['boring_thread_mode']}"
+        )
+        # --- END NEW ---
 
         # --- NOUVEAU : Préserver la sortie linéaire ---
         defaults_dict["preserve_linear_output"] = False
@@ -2195,6 +2224,22 @@ class SettingsManager:
                 self.use_third_party_solver = current_use_solver_val
             # --- FIN NOUVEAU ---
 
+            # --- NEW: Validation of boring_thread_mode ---
+            logger.debug("    -> Validating boring_thread_mode...")
+            current_boring_val = getattr(
+                self,
+                "boring_thread_mode",
+                defaults_fallback["boring_thread_mode"],
+            )
+            if not isinstance(current_boring_val, bool):
+                messages.append(
+                    f"Option 'Boring Thread Mode' ('{current_boring_val}') invalide, réinitialisée à {defaults_fallback['boring_thread_mode']}."
+                )
+                self.boring_thread_mode = defaults_fallback["boring_thread_mode"]
+            else:
+                self.boring_thread_mode = current_boring_val
+            # --- END NEW ---
+
             logger.debug("    -> Validating reproject_coadd_final...")
             current_rc_val = getattr(
                 self,
@@ -2547,6 +2592,11 @@ class SettingsManager:
                 getattr(self, "use_third_party_solver", True)
             ),
             # --- FIN NOUVEAU ---
+            # --- NEW: Save boring thread mode ---
+            "boring_thread_mode": bool(
+                getattr(self, "boring_thread_mode", False)
+            ),
+            # --- END NEW ---
             "local_solver_preference": str(
                 getattr(self, "local_solver_preference", "none")
             ),

--- a/seestar/localization/en.py
+++ b/seestar/localization/en.py
@@ -41,6 +41,8 @@ EN_TRANSLATIONS = {
     "kappa_value": "Kappa:",
     "batch_size": "Batch Size:",
     "batch_size_auto": "(0=auto)",  # Gardé même si 0 n'est plus auto pour compatibilité affichage
+    "enable_boring_thread": "Threaded Boring Stack",
+    "tooltip_enable_boring_thread": "Runs boring_stack.py in a background thread and sets batch size to 0.",
     "hot_pixels_correction": "Hot Pixel Correction",
     "perform_hot_pixels_correction": "Correct hot pixels",
     "hot_pixel_threshold": "Threshold:",

--- a/seestar/localization/fr.py
+++ b/seestar/localization/fr.py
@@ -40,6 +40,8 @@ FR_TRANSLATIONS = {
     "kappa_value": "Kappa :",
     "batch_size": "Taille Lot :",
     "batch_size_auto": "(0=auto)",  # Gardé pour affichage
+    "enable_boring_thread": "Empilement Boring en Thread",
+    "tooltip_enable_boring_thread": "Lance boring_stack.py en arrière-plan et force batch_size à 0.",
     "hot_pixels_correction": "Correction Pixels Chauds",
     "perform_hot_pixels_correction": "Corriger pixels chauds",
     "hot_pixel_threshold": "Seuil :",


### PR DESCRIPTION
## Summary
- add `Threaded Boring Stack` checkbox in the GUI that sets batch size to 0
- support new setting `boring_thread_mode` in `SettingsManager`
- update translations for the new control
- document the threaded boring stack mode in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688277e430b4832fbb9449d62955c9b3