### PR TITLE
Fix normalization for read-only arrays

### DIFF
--- a/seestar/core/normalization.py
+++ b/seestar/core/normalization.py
@@ -50,6 +50,9 @@ def _normalize_images_sky_mean(image_list, reference_index=0, sky_percentile=25.
             normalized.append(None)
             continue
         data = img.astype(np.float32, copy=False)
+        # Ensure the array is writeable for in-place adjustment
+        if not data.flags.writeable:
+            data = data.copy()
         if i == reference_index:
             normalized.append(data)
             continue


### PR DESCRIPTION
## Summary
- make `_normalize_images_sky_mean` copy arrays when required

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833058eb84832f8eb35abede0b1529