### PR TITLE
Fix NameError in summary generation

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -5267,8 +5267,9 @@ class SeestarStackerGUI:
         self.logger.info(
             "  [PF_S4 - MODIFIÉ FINAL AUTOSTRETCH] _processing_finished: Préparation données pour aperçu/histogramme final..."
         )
+        preview_load_error_msg = None
         def _load_final_preview():
-            nonlocal processing_error_details
+            nonlocal processing_error_details, preview_load_error_msg
             try:
                 data_final = None
                 header_final = None


### PR DESCRIPTION
## Summary
- ensure preview_load_error_msg is defined in `_processing_finished`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833773bc98832fb2e374941613249c