### PR TITLE
Fix variable capture in _prep_error

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6142,7 +6142,7 @@ class SeestarStackerGUI:
             try:
                 special_single = self._prepare_single_batch_if_needed()
             except FileNotFoundError as fnfe:
-                def _prep_error():
+                def _prep_error(fnfe=fnfe):
                     messagebox.showerror(
                         self.tr("error"),
                         self.tr(


### PR DESCRIPTION
## Summary
- ensure `_prep_error` in `main_window.py` retains the raised exception

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835224aa40832fac2000ef775d7a6b