### PR TITLE
Fix progress parsing in boring stack

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4386,7 +4386,7 @@ class SeestarStackerGUI:
                     log_file.write(text + "\n")
                     log_file.flush()
                     output_lines.append(text)
-                    pct_match = re.search(r"(?:\[(\d+(?:\.\d+)?)%\]|(\d+(?:\.\d+)?)%)", text)
+                    pct_match = re.search(r"^\s*(?:\[(\d+(?:\.\d+)?)%\]|(\d+(?:\.\d+)?)%)", text)
                     if pct_match:
                         try:
                             pct = float(next(filter(None, pct_match.groups())))


### PR DESCRIPTION
## Summary
- stop mis-detecting percentage markers in boring stack progress output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688359802fe0832f872bccbe43882508