### PR TITLE
Fix progress parsing for threaded boring stack

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4386,7 +4386,7 @@ class SeestarStackerGUI:
                     log_file.write(text + "\n")
                     log_file.flush()
                     output_lines.append(text)
-                    pct_match = re.search(r"^\s*(?:\[(\d+(?:\.\d+)?)%\]|(\d+(?:\.\d+)?)%)", text)
+                    pct_match = re.search(r"(?:\[(\d+(?:\.\d+)?)%\]|(\d+(?:\.\d+)?)%)", text)
                     if pct_match:
                         try:
                             pct = float(next(filter(None, pct_match.groups())))

--- a/tests/test_boring_thread_regex.py
+++ b/tests/test_boring_thread_regex.py
@@ -1,0 +1,8 @@
+import re
+
+def test_boring_thread_progress_regex_matches_timestamp():
+    line = "2024-01-01 00:00:00 [INFO] worker: [42%] processing"
+    m = re.search(r"(?:\[(\d+(?:\.\d+)?)%\]|(\d+(?:\.\d+)?)%)", line)
+    assert m
+    pct = float(next(filter(None, m.groups())))
+    assert pct == 42.0


### PR DESCRIPTION
## Summary
- fix regex to detect progress values in `boring_stack` log output
- cover timestamped progress lines in a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835f3624e0832f9b1a76375288b081