### PR TITLE
Refactor GUI threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Seestar Stacker est une application graphique conçue pour aligner et empiler de
 *   **Winsorized Sigma Clip:** Rejected pixels are automatically replaced with the winsorized limits.
 *   **Quality Weighting (Optional but Recommended):** Analyzes each aligned frame based on Signal-to-Noise Ratio (SNR) and Star Count/Sharpness, assigns weights, and allows tuning via exponents and minimum weight.
 *   **Asynchronous Processing:** Performs alignment and stacking in a background thread, keeping the GUI responsive.
+*   **Thread-Safe Event Queue:** Worker threads post GUI updates to an internal queue polled on the Tk thread.
 *   **Batch Processing:** Processes images in memory-efficient batches.
 *   **Graphical User Interface (Tkinter):**
     *   Intuitive tabbed interface.

--- a/zemosaic/CHANGELOG.md
+++ b/zemosaic/CHANGELOG.md
@@ -6,3 +6,4 @@
 * Added configurable `winsor_worker_limit` (CLI `--winsor-workers` / `-W` and GUI field)
 * Manual frame cap via `max_raw_per_master_tile` (CLI/GUI/config)
 * Fixed incremental assembly with reproject>=0.11
+* GUI startup no longer blocks thanks to a dedicated starter thread and event queue


### PR DESCRIPTION
## Summary
- add GuiEventQueue to marshal thread-safe events
- start backend from a dedicated starter thread
- poll the GUI event queue on the Tk thread
- lock additional folder count without blocking
- document new model and changelog entry

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688786d19368832f83f838ed49e5883a