### PR TITLE
Fix GUI freeze by limiting event processing

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4692,14 +4692,16 @@ class SeestarStackerGUI:
     def _poll_gui_events(self):
         """Process queued GUI events from worker threads."""
         if hasattr(self, "gui_event_queue"):
+            processed = 0
             try:
-                while True:
+                while processed < 100:
                     cb = self.gui_event_queue.get_nowait()
                     try:
                         if callable(cb):
                             cb()
                     finally:
                         self.gui_event_queue.task_done()
+                    processed += 1
             except Empty:
                 pass
         try:


### PR DESCRIPTION
## Summary
- refine `_poll_gui_events` in `main_window.py` to process at most 100 events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878d07549c832fb33ad99cc9e13ca5