### PR TITLE
Fix large-batch boring stack threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,9 @@ rotation drifts are eliminated.
 The aligner normally keeps intermediate arrays in memory. For very large
 images you can reduce memory usage by performing alignment on disk-backed
 ``.npy`` files. Pass ``align_on_disk=True`` when using ``SeestarQueuedStacker``
-from Python or add ``--align-on-disk`` to ``boring_stack.py``.
+from Python or add ``--align-on-disk`` to ``boring_stack.py``. When more than
+50 images are queued and this flag is omitted, ``boring_stack.py`` now
+automatically enables disk-backed alignment to avoid running out of memory.
 
 ### Command-Line Stacking
 

--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -251,6 +251,19 @@ def main() -> int:
         logger.error("CSV is empty")
         return 1
 
+    # Auto-enable disk-backed alignment when processing extremely large
+    # batches so memory usage stays bounded.  This mirrors the behaviour of
+    # the GUI which suggests enabling the option for huge lists.
+    if (
+        args.batch_size == 1
+        and not args.align_on_disk
+        and len(rows) > 50
+    ):
+        logger.warning(
+            "Large batch detected (>50 images) - enabling align_on_disk"
+        )
+        args.align_on_disk = True
+
     ordered_files = [r["path"] for r in rows]
     file_list = ordered_files
     out_path = os.path.join(args.out, "final.fits")


### PR DESCRIPTION
## Summary
- auto-switch to disk-backed alignment when boring_stack processes more than 50 images
- document the new automatic behaviour in README

## Testing
- `pytest -k boring_thread -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888003ebac8832fb5c6c91a21d78bd3