### PR TITLE
Fix disk-backed boring stack memory limit

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -8594,6 +8594,7 @@ class SeestarQueuedStacker:
                         q_slice,
                         kappa=kappa,
                         winsor_limits=winsor_limits,
+                        max_mem_bytes=max_bytes,
                     )
                 elif (
                     mode == "kappa-sigma"
@@ -8959,6 +8960,7 @@ class SeestarQueuedStacker:
                         quality_weights,
                         kappa=max(self.stack_kappa_low, self.stack_kappa_high),
                         winsor_limits=self.winsor_limits,
+                        max_mem_bytes=self.max_hq_mem,
                     )
                     gc.collect()  # FIX MEMLEAK
                 batch_coverage_map_2d = coverage_sum.astype(np.float32)
@@ -9508,6 +9510,7 @@ class SeestarQueuedStacker:
                         w_cube,
                         kappa=self.stack_kappa_high,
                         winsor_limits=self.winsor_limits,
+                        max_mem_bytes=self.max_hq_mem,
                     )
                     gc.collect()  # FIX MEMLEAK
                 elif self.stack_final_combine == "median":

--- a/tests/test_rewinsorization.py
+++ b/tests/test_rewinsorization.py
@@ -62,7 +62,7 @@ def test_stack_batch_calls_winsor(monkeypatch, tmp_path):
 
     calls = {"n": 0}
 
-    def fake_winsor(self, images, weights, kappa=3.0, winsor_limits=(0.05, 0.05), apply_rewinsor=True):
+    def fake_winsor(self, images, weights, kappa=3.0, winsor_limits=(0.05, 0.05), apply_rewinsor=True, **kwargs):
         calls["n"] += 1
         return np.zeros_like(images[0]), 0.0
 


### PR DESCRIPTION
## Summary
- pass `max_mem_bytes` limit to `_stack_winsorized_sigma` so disk-backed stacking works for large batch-size=1
- update unit test helper for new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688873966c8c832f84b7a4ffbaec4ad1