### PR TITLE
Fix disk stacking for batch size 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,11 @@ chunks of N images so incremental stacking works without a `stack_plan.csv`.
 If a `stack_plan.csv` is present, it will be ignored unless `--chunk-size` is
 omitted.
 
+When using `--batch-size 1` together with `--align-on-disk`, aligned frames are
+written to an `aligned_tmp` directory and reused when the final stack is
+assembled. These temporary files are cleaned up automatically once processing
+finishes.
+
 ### Threaded Boring Stack from the GUI
 
 Set **Batch Size** to `1` or tick the *Threaded Boring Stack* checkbox in the

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -6739,21 +6739,22 @@ class SeestarQueuedStacker:
 
         # Clean up any temporary aligned files used for this batch
         if getattr(self, "batch_size", 1) == 1:
-            for item in batch_items_to_stack:
-                if isinstance(item[0], str) and os.path.exists(item[0]):
-                    try:
-                        os.remove(item[0])
-                    except Exception:
-                        pass
-                if (
-                    len(item) > 4
-                    and isinstance(item[4], str)
-                    and os.path.exists(item[4])
-                ):
-                    try:
-                        os.remove(item[4])
-                    except Exception:
-                        pass
+            if not self.align_on_disk:
+                for item in batch_items_to_stack:
+                    if isinstance(item[0], str) and os.path.exists(item[0]):
+                        try:
+                            os.remove(item[0])
+                        except Exception:
+                            pass
+                    if (
+                        len(item) > 4
+                        and isinstance(item[4], str)
+                        and os.path.exists(item[4])
+                    ):
+                        try:
+                            os.remove(item[4])
+                        except Exception:
+                            pass
 
     def _flush_current_batch(
         self,


### PR DESCRIPTION
## Summary
- keep aligned tmp files while processing single-batch runs
- mention aligned_tmp behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887a13d2e4832f940a3a8ae3aeb856