### PR TITLE
Fix special single batch size handling

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -12667,7 +12667,6 @@ class SeestarQueuedStacker:
                 self.files_in_queue += 1
                 self.all_input_filepaths.append(abs_fp)
             batch_len = len(ordered_files)
-            self.batch_size = batch_len if batch_len > 0 else 1
             self.total_batches_estimated = 1
             self.update_progress(
                 f"📋 {self.files_in_queue} fichiers initiaux ajoutés depuis stack_plan.csv"


### PR DESCRIPTION
## Summary
- keep `batch_size` at 1 when using `stack_plan.csv` with `--batch-size 1`

## Testing
- `pytest -k single_batch_csv -q`

------
https://chatgpt.com/codex/tasks/task_e_68888ab1d900832fb6c59142654c3cd6