### PR TITLE
Add preview callback for single-batch final stack

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -10864,6 +10864,8 @@ class SeestarQueuedStacker:
                         final_wht_map_for_postproc = np.ones(
                             final_image_initial_raw.shape[:2], dtype=np.float32
                         )
+                        if self.enable_preview and self.preview_callback:
+                            self.preview_callback(final_image_initial_raw)
                         os.remove(stacked_path)
                         for p in self.aligned_temp_paths:
                             try:


### PR DESCRIPTION
## Summary
- trigger preview callback when streaming single-batch final stack creation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ecd66910832f9461a5a4df7d629f