### PR TITLE
Fix stacking when batch_size=1

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -8919,7 +8919,7 @@ class SeestarQueuedStacker:
             use_memmap = False
             try:
                 batch_sz = getattr(self.settings, "batch_size", self.batch_size)
-                if int(batch_sz) == 1:
+                if int(batch_sz) == 1 and num_valid_images_for_processing > 1:
                     use_memmap = True
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- avoid memmap tile mode if only one image is in the batch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889235adc4c832fa00eddc3936cbbaa