### PR TITLE
Fix progress parsing in BoringStack GUI

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4442,6 +4442,7 @@ class SeestarStackerGUI:
                     log_file.flush()
                     output_lines.append(text)
                     pct_match = re.search(r"(?:\[(\d+(?:\.\d+)?)%\]|(\d+(?:\.\d+)?)%)", text)
+                    aligned_match = re.search(r"Aligned:\s*(\d+)", text)
                     if pct_match:
                         try:
                             pct = float(next(filter(None, pct_match.groups())))
@@ -4458,7 +4459,10 @@ class SeestarStackerGUI:
                         else:
                             eta = self.tr("eta_calculating", default="Calculating...")
 
-                        processed = int(round((pct / 100.0) * total_files))
+                        if aligned_match:
+                            processed = int(aligned_match.group(1))
+                        else:
+                            processed = int(round((pct / 100.0) * total_files))
                         if processed < last_processed:
                             processed = last_processed
                         last_pct = pct


### PR DESCRIPTION
## Summary
- parse the `Aligned:` message when reading `boring_stack.py` output
- use aligned count when computing processed image count

## Testing
- `pytest -k boring_thread -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a726bce7c832fafd73887fc9ea4bb