### PR TITLE
Fix progress tracking for single batch size

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4443,11 +4443,16 @@ class SeestarStackerGUI:
                     output_lines.append(text)
                     pct_match = re.search(r"(?:\[(\d+(?:\.\d+)?)%\]|(\d+(?:\.\d+)?)%)", text)
                     aligned_match = re.search(r"Aligned:\s*(\d+)", text)
-                    if pct_match:
-                        try:
-                            pct = float(next(filter(None, pct_match.groups())))
-                        except (ValueError, StopIteration):
-                            continue
+                    if pct_match or aligned_match:
+                        if pct_match:
+                            try:
+                                pct = float(next(filter(None, pct_match.groups())))
+                            except (ValueError, StopIteration):
+                                continue
+                        else:
+                            processed = int(aligned_match.group(1))
+                            pct = processed / total_files * 100 if total_files else 0
+
                         if pct < last_pct:
                             pct = last_pct
                         elapsed = time.monotonic() - start_time

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1896,10 +1896,12 @@ class SeestarQueuedStacker:
         with self.counter_lock:
             self.aligned_counter += 1
             current_aligned = self.aligned_counter
-        total = getattr(self, "files_in_queue", 1) or 1
-        self.update_progress(
-            f"Aligned: {current_aligned}", current_aligned / total * 100
-        )
+
+        files_in_queue = getattr(self, "files_in_queue", 0) or 0
+        total = max(files_in_queue, current_aligned) or 1
+        current_pct = current_aligned / total * 100
+
+        self.update_progress(f"Aligned: {current_aligned}", current_pct)
 
     ########################################################################################################################################################
 


### PR DESCRIPTION
## Summary
- fix increment of aligned counter to avoid 100% on first update
- compute progress from `Aligned:` lines when boring stack doesn't output percent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a797c7be8832fa8205bb97084aba4