### PR TITLE
Fix summary dialog for single batch stacking

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -4290,6 +4290,11 @@ class SeestarStackerGUI:
     def _run_boring_stack_process(self, cmd, csv_path, out_dir):
         """Execute ``boring_stack.py`` without blocking the GUI."""
 
+        if hasattr(self, "output_path") and not self.output_path.get():
+            # Record path early so the summary dialog can enable
+            # the "Open Output" button when the stack completes.
+            self.output_path.set(out_dir)
+
         def _worker():
             total_files = 0
             try:
@@ -4341,13 +4346,6 @@ class SeestarStackerGUI:
                                 self.tr("stacking_finished", default="Stacking finished"),
                                 100,
                             )
-                            try:
-                                messagebox.showinfo(
-                                    "Stack complete",
-                                    f"Output written to {final_path}",
-                                )
-                            except tk.TclError:
-                                pass
                     else:
                         tail = "\n".join(output_lines[-10:])
                         err_msg = (


### PR DESCRIPTION
## Summary
- avoid blocking messagebox when running boring stacker
- set output path when starting boring stack
- clarify purpose of output path update

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a8837856c832f96a88f50fa3f2ca6