### PR TITLE
Fix HQ RAM limit in batch mode

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6234,6 +6234,8 @@ class SeestarStackerGUI:
                 self.settings.output_folder,
                 "--batch-size",
                 "1",
+                "--max-mem",
+                str(getattr(self.settings, "max_hq_mem_gb", 8)),
             ]
             self._run_boring_stack_process(cmd, csv_path, self.settings.output_folder)
             return


### PR DESCRIPTION
## Summary
- propagate `HQ RAM limit (GB)` from GUI to `boring_stack.py`
- make `--max-mem` actively set the stacker memory limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b00cf5978832f941ff068d4a253ba