### PR TITLE
Apply auto chunk-size for threaded boring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,9 @@ automatically enables disk-backed alignment to avoid running out of memory.
 ### Command-Line Stacking
 
 Use `seestar/gui/boring_stack.py` for headless single-batch processing. Set
-`--chunk-size` to periodically flush intermediate stacks:
+`--chunk-size` to periodically flush intermediate stacks. When the GUI launches
+`boring_stack.py` with **Batch Size** set to `1`, this option is automatically
+added based on available system RAM:
 
 ```bash
 python seestar/gui/boring_stack.py --csv stack_plan.csv --out OUT_DIR \
@@ -418,10 +420,11 @@ finishes.
 ### Threaded Boring Stack from the GUI
 
 Set **Batch Size** to `1` or tick the *Threaded Boring Stack* checkbox in the
-Stacking tab. The GUI will launch `boring_stack.py` in a background thread using
-your `stack_plan.csv` and display progress as it runs.
-When a `stack_plan.csv` is present, the entire list is stacked as one batch and
-the chunk size parameter is ignored.
+Stacking tab. The GUI launches `boring_stack.py` in a background thread using
+your `stack_plan.csv` and displays progress as it runs. A chunk size is
+automatically calculated and passed to the script so memory usage stays
+bounded. When calling `boring_stack.py` directly, specifying `--chunk-size`
+will override any grouping defined in `stack_plan.csv`.
 
 
 ---

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6236,6 +6236,8 @@ class SeestarStackerGUI:
                 "1",
                 "--max-mem",
                 str(getattr(self.settings, "max_hq_mem_gb", 8)),
+                "--chunk-size",
+                str(self._get_auto_chunk_size()),
             ]
             self._run_boring_stack_process(cmd, csv_path, self.settings.output_folder)
             return


### PR DESCRIPTION
## Summary
- propagate automatic chunk-size when launching `boring_stack.py`
- document threaded boring stack behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b37e68db8832fa10a84c42fe0b4ff