### PR TITLE
Fix intermediate batch display with zero batch size

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4045,7 +4045,7 @@ class SeestarQueuedStacker:
                                     getattr(self, "chunk_size", None)
                                     if self.batch_size == 1
                                     and getattr(self, "chunk_size", None)
-                                    else self.batch_size
+                                    else max(1, self.batch_size)
                                 )
                                 if (
                                     len(current_batch_items_with_masks_for_stack_batch)
@@ -4263,7 +4263,7 @@ class SeestarQueuedStacker:
                                     getattr(self, "chunk_size", None)
                                     if self.batch_size == 1
                                     and getattr(self, "chunk_size", None)
-                                    else self.batch_size
+                                    else max(1, self.batch_size)
                                 )
                                 if (
                                     len(current_batch_items_with_masks_for_stack_batch)


### PR DESCRIPTION
## Summary
- handle batch_size values of 0 when determining the flush trigger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d08c7705c832f8cbe484cd435086f