### PR TITLE
Honor final combine settings in boring_stack

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -11,6 +11,8 @@ import psutil
 import signal
 import numpy as np
 
+from seestar.gui.settings import SettingsManager
+
 _PROC = psutil.Process(os.getpid())  # Track process RAM for DEBUG logs
 
 # Global reference to the running stacker for signal handlers
@@ -384,7 +386,14 @@ def _run_stack(args, progress_cb) -> int:
         except (ValueError, TypeError):
             bytes_limit = None
 
-    stacker = SeestarQueuedStacker(align_on_disk=args.align_on_disk)
+    # Load user settings so final combine preferences are honoured
+    settings = SettingsManager()
+    try:
+        settings.load_settings()
+    except Exception:
+        settings.reset_to_defaults()
+
+    stacker = SeestarQueuedStacker(align_on_disk=args.align_on_disk, settings=settings)
     global _GLOBAL_STACKER
     _GLOBAL_STACKER = stacker
     try:
@@ -416,7 +425,8 @@ def _run_stack(args, progress_cb) -> int:
             stars_exp=args.stars_exp,
             min_w=args.min_weight,
             use_drizzle=False,
-            reproject_between_batches=False,
+            reproject_between_batches=settings.reproject_between_batches,
+            reproject_coadd_final=settings.reproject_coadd_final,
             api_key=args.api_key,
             perform_cleanup=args.cleanup_temp_files,
         )


### PR DESCRIPTION
## Summary
- load user settings in `boring_stack.py` so the chosen final combine method is respected
- pass `reproject_between_batches` and `reproject_coadd_final` to `start_processing`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d4fbd24d0832fbf5b6b0927892e6d