### PR TITLE
Forward ASTAP solver settings in boring stacker

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -457,7 +457,16 @@ def _run_stack(args, progress_cb) -> int:
         )
         args.align_on_disk = True
 
-    stacker = SeestarQueuedStacker(align_on_disk=args.align_on_disk, settings=settings)
+    stacker = SeestarQueuedStacker(
+        align_on_disk=args.align_on_disk,
+        settings=settings,
+        local_solver_preference=settings.local_solver_preference,
+        astap_path=settings.astap_path,
+        astap_data_dir=settings.astap_data_dir,
+        astap_search_radius=settings.astap_search_radius,
+        astap_downsample=settings.astap_downsample,
+        astap_sensitivity=settings.astap_sensitivity,
+    )
     global _GLOBAL_STACKER
     _GLOBAL_STACKER = stacker
     try:


### PR DESCRIPTION
## Summary
- pass local ASTAP solver configuration from SettingsManager to `SeestarQueuedStacker`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dd7a32e98832fa56dc5838ceaf4e7