### PR TITLE
Sanitise ASTAP WCS CONTINUE cards

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -142,6 +142,48 @@ logger = logging.getLogger(__name__)
 
 
 # -----------------------------------------------------------------------------
+# ASTAP WCS helpers
+# -----------------------------------------------------------------------------
+
+def _sanitize_astap_wcs(path: str) -> None:
+    """Ensure CONTINUE card values in ASTAP ``.wcs`` sidecars are strings.
+
+    ``path`` may point either to the original FITS file or directly to the
+    ``.wcs`` sidecar produced by ASTAP.
+    """
+    wcs_path = path if path.lower().endswith(".wcs") else os.path.splitext(path)[0] + ".wcs"
+    if not os.path.exists(wcs_path):
+        return
+    try:
+        # Primary attempt: treat the sidecar as a minimal FITS file
+        with fits.open(wcs_path, mode="update") as hdul:  # pragma: no cover - best effort
+            hdr = hdul[0].header
+            modified = False
+            for card in hdr.cards:
+                if card.keyword == "CONTINUE" and not isinstance(card.value, str):
+                    card.value = str(card.value)
+                    modified = True
+            if modified:
+                hdul.flush()
+            return
+    except Exception:
+        pass
+    # Fallback: some ASTAP ``.wcs`` files are plain text headers
+    try:  # pragma: no cover - best effort
+        header = fits.Header.fromfile(wcs_path, sep="\n")
+        modified = False
+        for card in header.cards:
+            if card.keyword == "CONTINUE" and not isinstance(card.value, str):
+                card.value = str(card.value)
+                modified = True
+        if modified:
+            with open(wcs_path, "w", newline="\n") as f:
+                f.write(header.tostring(sep="\n"))
+    except Exception:
+        logger.debug("Échec de la correction CONTINUE pour %s", wcs_path, exc_info=True)
+
+
+# -----------------------------------------------------------------------------
 # CSV helpers (reused by GUI)
 # -----------------------------------------------------------------------------
 
@@ -477,6 +519,15 @@ def _run_stack(args, progress_cb) -> int:
             except Exception:
                 pass
         stacker.progress_callback = progress_cb
+
+        if args.batch_size == 1 and stacker.astrometry_solver:
+            _orig_parse_wcs = stacker.astrometry_solver._parse_wcs_file_content
+
+            def _patched_parse_wcs_file_content(wcs_path, img_shape_hw, _orig=_orig_parse_wcs):
+                _sanitize_astap_wcs(wcs_path)
+                return _orig(wcs_path, img_shape_hw)
+
+            stacker.astrometry_solver._parse_wcs_file_content = _patched_parse_wcs_file_content
 
         # ------------------------------------------------------------------
         # Pré-plate-solving des fichiers FITS sources (batch_size=1 uniquement)

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -6055,6 +6055,7 @@ class SeestarQueuedStacker:
         valid_pixel_mask_2d = None
         matrice_M_calculee = None
         align_method_log_msg = "Unknown"
+        tmp_align_in_path = None
 
         try:
             logger.debug(f"  -> [1/7] Chargement/Validation FITS pour '{file_name}'...")
@@ -6168,7 +6169,6 @@ class SeestarQueuedStacker:
                 f"     - (e) is_drizzle_or_mosaic_mode: {is_drizzle_or_mosaic_mode}"
             )
 
-            tmp_align_in_path = None
             if align_on_disk:
                 tmp_align_in_path = tempfile.mktemp(suffix=".npy")
                 mm_in = np.lib.format.open_memmap(


### PR DESCRIPTION
## Summary
- ensure ASTAP-produced `.wcs` sidecars have string values for any CONTINUE cards
- patch ASTAP solver hook in `boring_stack.py` so the fix runs before each parse when `batch_size=1`
- guard `tmp_align_in_path` initialization in `queue_manager` to avoid `UnboundLocalError` on early exit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dec32eb34832fa9548cf85e0bf120