### PR TITLE
Enable GUI-driven Reproject & Coadd final stacking

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -629,6 +629,8 @@ def _run_stack(args, progress_cb) -> int:
         settings.load_settings()
     except Exception:
         settings.reset_to_defaults()
+    if getattr(settings, "stack_final_combine", "") == "reproject_coadd":
+        settings.reproject_coadd_final = True
 
     # When using Reproject+Coadd with single-image batches we must retain
     # each aligned FITS on disk so that an external astrometric solver can

--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -491,8 +491,8 @@ class SeestarStackerGUI:
         self.stack_norm_method_var = tk.StringVar(value="none")
         self.stack_weight_method_var = tk.StringVar(value="none")
         self.stack_reject_algo_var = tk.StringVar(value="kappa_sigma")
-        # Default final combine to "Reproject & Coadd"
-        self.stack_final_combine_var = tk.StringVar(value="reproject_coadd")
+        # Default final combine method
+        self.stack_final_combine_var = tk.StringVar(value="mean")
         self.stacking_kappa_low_var = tk.DoubleVar(value=3.0)
         self.stacking_kappa_high_var = tk.DoubleVar(value=3.0)
         self.stacking_winsor_limits_str_var = tk.StringVar(value="0.05,0.05")
@@ -599,8 +599,8 @@ class SeestarStackerGUI:
             f"DEBUG (GUI init_variables): Variable use_third_party_solver_var créée (valeur initiale: {self.use_third_party_solver_var.get()})."
         )
         self.reproject_between_batches_var = tk.BooleanVar(value=False)
-        # Default final combine selection is "Reproject & Coadd"
-        self.reproject_coadd_var = tk.BooleanVar(value=True)
+        # Separate toggle for final reproject+coadd
+        self.reproject_coadd_var = tk.BooleanVar(value=False)
         self.ansvr_host_port_var = tk.StringVar(value="127.0.0.1:8080")
 
         self.astrometry_solve_field_dir_var = tk.StringVar(value="")

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -170,7 +170,7 @@ class SettingsManager:
                     gui_instance,
                     "stack_final_combine_var",
                     tk.StringVar(
-                        value=default_values_from_code.get("stack_final_combine", "reproject_coadd")
+                        value=default_values_from_code.get("stack_final_combine", "mean")
                     ),
                 ).get()
             self.stack_method = getattr(
@@ -715,6 +715,8 @@ class SettingsManager:
                     )
                 ),
             ).get()
+            if self.stack_final_combine == "reproject_coadd":
+                self.reproject_coadd_final = True
 
             # In classic stacking mode this option defaults to disabled unless
             # the user explicitly checked the box in the Local Solver window.
@@ -821,6 +823,8 @@ class SettingsManager:
             getattr(gui_instance, "stacking_winsor_limits_str_var", tk.StringVar()).set(
                 self.stack_winsor_limits
             )
+            if getattr(self, "reproject_coadd_final", False):
+                self.stack_final_combine = "reproject_coadd"
             getattr(gui_instance, "stack_final_combine_var", tk.StringVar()).set(
                 self.stack_final_combine
             )
@@ -1255,8 +1259,8 @@ class SettingsManager:
         defaults_dict["stack_kappa_low"] = 3.0
         defaults_dict["stack_kappa_high"] = 3.0
         defaults_dict["stack_winsor_limits"] = "0.05,0.05"
-        # Default to Reproject & Coadd for final combine
-        defaults_dict["stack_final_combine"] = "reproject_coadd"
+        # Default final combination method
+        defaults_dict["stack_final_combine"] = "mean"
         defaults_dict["max_hq_mem_gb"] = 8
         defaults_dict["stack_method"] = "kappa_sigma"
         defaults_dict["correct_hot_pixels"] = True
@@ -1368,8 +1372,8 @@ class SettingsManager:
         # When enabled, each batch is solved and reprojected incrementally onto
         # the reference WCS.
         defaults_dict["reproject_between_batches"] = False
-        # Default to "Reproject & Coadd" for the final combine option
-        defaults_dict["reproject_coadd_final"] = True
+        # Enable final reproject+coadd only when explicitly requested
+        defaults_dict["reproject_coadd_final"] = False
 
         defaults_dict["mosaic_mode_active"] = False
         defaults_dict["mosaic_settings"] = {

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1257,7 +1257,10 @@ class SeestarQueuedStacker:
                 self.freeze_reference_wcs = self.reproject_between_batches
                 self.reproject_coadd_final = bool(
                     getattr(settings, "reproject_coadd_final", False)
+                    or getattr(settings, "stack_final_combine", "") == "reproject_coadd"
                 )
+                if self.reproject_coadd_final:
+                    self.stack_final_combine = "reproject_coadd"
                 logger.debug(
                     f"  -> Flag reproject_coadd_final initialisé depuis settings: {self.reproject_coadd_final}"
                 )


### PR DESCRIPTION
## Summary
- default final combine method is mean, enabling Reproject+Coadd only when chosen
- propagate GUI selection to SettingsManager and queue stacker
- respect final reproject & coadd option in CLI boring stack

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689879fbc390832fb2ce203c73be24b7