### PR TITLE
Ensure reproject-and-coadd option is honored

### DIFF
--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -161,18 +161,17 @@ class SettingsManager:
                     )
                 ),
             ).get()
-            if getattr(gui_instance, "reproject_between_batches_var", tk.BooleanVar()).get():
-                self.stack_final_combine = "reproject"
-            elif getattr(gui_instance, "reproject_coadd_var", tk.BooleanVar()).get():
-                self.stack_final_combine = "reproject_coadd"
-            else:
-                self.stack_final_combine = getattr(
-                    gui_instance,
-                    "stack_final_combine_var",
-                    tk.StringVar(
-                        value=default_values_from_code.get("stack_final_combine", "mean")
-                    ),
-                ).get()
+            self.stack_final_combine = getattr(
+                gui_instance,
+                "stack_final_combine_var",
+                tk.StringVar(
+                    value=default_values_from_code.get("stack_final_combine", "mean")
+                ),
+            ).get()
+            self.reproject_between_batches = self.stack_final_combine == "reproject"
+            self.reproject_coadd_final = (
+                self.stack_final_combine == "reproject_coadd"
+            )
             self.stack_method = getattr(
                 gui_instance,
                 "stack_method_var",
@@ -695,28 +694,6 @@ class SettingsManager:
                 "astrometry_solve_field_dir",
                 default_values_from_code.get("astrometry_solve_field_dir", ""),
             )
-
-            self.reproject_between_batches = getattr(
-                gui_instance,
-                "reproject_between_batches_var",
-                tk.BooleanVar(
-                    value=default_values_from_code.get(
-                        "reproject_between_batches", False
-                    )
-                ),
-            ).get()
-
-            self.reproject_coadd_final = getattr(
-                gui_instance,
-                "reproject_coadd_var",
-                tk.BooleanVar(
-                    value=default_values_from_code.get(
-                        "reproject_coadd_final", False
-                    )
-                ),
-            ).get()
-            if self.stack_final_combine == "reproject_coadd":
-                self.reproject_coadd_final = True
 
             # In classic stacking mode this option defaults to disabled unless
             # the user explicitly checked the box in the Local Solver window.

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1275,7 +1275,8 @@ class SeestarQueuedStacker:
         self.stack_kappa_low = 2.5
         self.stack_kappa_high = 2.5
         self.winsor_limits = (0.05, 0.05)
-        self.stack_final_combine = "mean"
+        if not getattr(self, "stack_final_combine", None):
+            self.stack_final_combine = "mean"
         self.stack_reject_algo = "none"
         self.hot_pixel_threshold = 3.0
         self.neighborhood_size = 5


### PR DESCRIPTION
## Summary
- Prevent queue manager from overwriting `stack_final_combine` after reading settings
- Derive reprojection flags directly from `stack_final_combine_var` in UI settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ba89ffbc832fa6a11bad2e6a3cbd