### PR TITLE
Implement streaming reproject and early logging setup

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6327,6 +6327,8 @@ class SeestarStackerGUI:
                 str(getattr(self.settings, "max_hq_mem_gb", 8)),
                 "--chunk-size",
                 str(self._get_auto_chunk_size()),
+                "--log-dir",
+                os.path.join(self.settings.output_folder, "logs"),
             ]
             final_combine_slug = _to_slug(self.stack_final_combine_var.get())
             cmd += ["--final-combine", final_combine_slug]


### PR DESCRIPTION
## Summary
- Configure root logging with rotating file output via new `_setup_logging` used by both CLI and GUI paths
- Add streaming `reproject_and_coadd` implementation using on-disk memmaps and tile processing for batch-size 1
- Pass `--log-dir` from the GUI when invoking `boring_stack.py` for consistent log files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b57e80130832fbc328228cd005e22