### PR TITLE
Fix memmap open fallback on Windows

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -1190,6 +1190,7 @@ class SeestarQueuedStacker:
         self.cumulative_wht_memmap = open_memmap(
             self.cumulative_wht_path, mode="w+", dtype=np.float32, shape=(H, W)
         )
+        self.cumulative_wht_path = self.cumulative_wht_memmap.filename
         self.cumulative_wht_memmap[:] = 0.0
 
         # Options pour déplacement et sauvegarde partiels


### PR DESCRIPTION
## Summary
- ensure memmap fallback uses a temporary file and raises clear errors
- track actual memmap path in queue manager to keep cleanup consistent

## Testing
- `pytest` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a86800ac832f85b49ee73f6c8ac9