### PR TITLE
Fix FITS export reliability for single-image batches

### DIFF
--- a/seestar/gui/__init__.py
+++ b/seestar/gui/__init__.py
@@ -4,21 +4,41 @@ pour le traitement des images astronomiques.
 (Fichiers redondants retirés: processing.py, ui_components.py)
 """
 
-from .main_window import SeestarStackerGUI
-# Expose other components if needed directly elsewhere, but usually main_window is enough
-from .preview import PreviewManager
-from .histogram_widget import HistogramWidget # Added import
-from .file_handling import FileHandlingManager
-from .progress import ProgressManager
-from .settings import SettingsManager
+# Delay heavy GUI imports so headless environments can import lightweight
+# helpers (e.g. ``boring_stack``) without requiring a display backend.
 
 __all__ = [
-    'SeestarStackerGUI',
-    'PreviewManager',
-    'HistogramWidget',      # Added export
-    'FileHandlingManager',
-    'ProgressManager',
-    'SettingsManager',
-    'ToolTip',
-    ]
+    "SeestarStackerGUI",
+    "PreviewManager",
+    "HistogramWidget",
+    "FileHandlingManager",
+    "ProgressManager",
+    "SettingsManager",
+    "boring_stack",
+]
+
+
+def __getattr__(name):  # pragma: no cover - simple lazy imports
+    if name == "SeestarStackerGUI":
+        from .main_window import SeestarStackerGUI
+        return SeestarStackerGUI
+    if name == "PreviewManager":
+        from .preview import PreviewManager
+        return PreviewManager
+    if name == "HistogramWidget":
+        from .histogram_widget import HistogramWidget
+        return HistogramWidget
+    if name == "FileHandlingManager":
+        from .file_handling import FileHandlingManager
+        return FileHandlingManager
+    if name == "ProgressManager":
+        from .progress import ProgressManager
+        return ProgressManager
+    if name == "SettingsManager":
+        from .settings import SettingsManager
+        return SettingsManager
+    if name == "boring_stack":
+        from . import boring_stack
+        return boring_stack
+    raise AttributeError(name)
 # --- END OF FILE seestar/gui/__init__.py ---

--- a/seestar/gui/reprojection_utils.py
+++ b/seestar/gui/reprojection_utils.py
@@ -1,0 +1,25 @@
+import logging
+import os
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from seestar.core.image_processing import sanitize_header_for_wcs
+
+logger = logging.getLogger(__name__)
+
+
+def load_wcs_header_only(path: str) -> WCS:
+    """Return ``WCS`` loaded from ``path`` without touching image data.
+
+    The header is read with ``ignore_missing_simple=True`` so truncated files
+    raise ``ValueError``. If the file is smaller than 2880 bytes or lacks the
+    ``SIMPLE`` card a ``ValueError`` is raised.
+    """
+    size = os.path.getsize(path)
+    if size < 2880:
+        raise ValueError(f"file too small ({size} bytes)")
+    hdr = fits.getheader(path, ignore_missing_simple=True, memmap=False)
+    if "SIMPLE" not in hdr:
+        raise ValueError("missing SIMPLE")
+    sanitize_header_for_wcs(hdr)
+    return WCS(hdr, naxis=2, relax=True)

--- a/seestar/utils/wcs_utils.py
+++ b/seestar/utils/wcs_utils.py
@@ -29,13 +29,20 @@ def _sanitize_continue_as_string(header: fits.Header) -> None:
         if k == "CONTINUE":
             header[k] = str(v)
 
-def write_wcs_to_fits_inplace(fits_path: str, wcs_obj: WCS) -> None:
+def write_wcs_to_fits_inplace(fits_path: str, wcs_obj: WCS, *, memmap: bool = True) -> None:
     """Persist ``wcs_obj`` into ``fits_path`` updating header only.
 
-    The FITS file is opened with ``memmap=True`` and data are left untouched.
-    Any previous WCS cards are removed before injecting the new solution.
+    Parameters
+    ----------
+    fits_path : str
+        Path to an existing FITS file.
+    wcs_obj : :class:`astropy.wcs.WCS`
+        WCS solution to write.
+    memmap : bool, optional
+        Passed to :func:`astropy.io.fits.open`. ``False`` avoids file locking on
+        Windows. Defaults to ``True`` for backward compatibility.
     """
-    with fits.open(fits_path, mode="update", memmap=True) as hdul:
+    with fits.open(fits_path, mode="update", memmap=memmap) as hdul:
         h = hdul[0].header
         _strip_wcs_cards(h)
         h_wcs = wcs_obj.to_header(relax=True)


### PR DESCRIPTION
## Summary
- ensure save_fits_image writes valid FITS headers and verifies SIMPLE
- inject WCS after FITS export and validate headers in boring_stack
- add robust header loader and safer temp file handling for batch-size=1 pipelines

## Testing
- `pytest tests/test_reproject_utils.py::test_finalize_coadd_removes_bscale -vv`
- `pytest` *(fails: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a2ef1b4c832fb9f0b1c846e43264