### PR TITLE
Ensure atomic FITS saving with header validation

### DIFF
--- a/seestar/core/image_processing.py
+++ b/seestar/core/image_processing.py
@@ -226,95 +226,57 @@ def debayer_image(img, bayer_pattern="GRBG"):
 
 
 def save_fits_image(image, output_path, header=None, overwrite=True):
-    """
-    Enregistre une image (normalisée 0-1 float32) au format FITS (uint16).
-    Suppresses specific FITS standard VerifyWarnings about keyword length.
+    if image is None or not isinstance(image, np.ndarray):
+        raise ValueError(f"Invalid image for FITS save: {type(image)}")
 
-    Parameters:
-        image (numpy.ndarray): Image 2D (HxW) ou 3D (HxWx3) à enregistrer (float32, 0-1).
-        output_path (str): Chemin du fichier de sortie.
-        header (astropy.io.fits.Header, optional): En-tête FITS.
-        overwrite (bool): Écrase le fichier existant si True.
-    """
-    # --- (Input validation remains the same) ---
-    if image is None:
-        print(f"Error: Cannot save None image to {output_path}")
-        return
-    if not isinstance(image, np.ndarray):
-        print(f"Error: Input for save_fits_image must be a numpy array, got {type(image)}")
-        return
-
-    # --- (Header creation/copying logic remains the same) ---
-    final_header = fits.Header()
-    if header is not None and isinstance(header, fits.Header):
-         keywords_to_remove = ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3',
-                              'EXTEND', 'BSCALE', 'BZERO']
-         temp_header = header.copy()
-         for key in keywords_to_remove:
-              if key in temp_header: del temp_header[key]
-         final_header.update(temp_header)
-    elif header is not None:
-         print("Warning: Provided header is not valid astropy.io.fits.Header. Creating new one.")
-
-
-    # --- (Data preparation logic remains the same) ---
+    # Prépare les données (0–1 -> uint16 -> int16 décalé)
     is_color = image.ndim == 3 and image.shape[-1] == 3
-    image_float32 = image.astype(np.float32)
-    image_clipped = np.clip(image_float32, 0.0, 1.0)
-    image_uint16 = (image_clipped * 65535.0).astype(np.uint16)
-    image_int16_shifted = (image_uint16.astype(np.int32) - 32768).astype(np.int16)
+    image_uint16 = (np.clip(image.astype(np.float32), 0.0, 1.0) * 65535.0).astype(np.uint16)
+    image_int16 = (image_uint16.astype(np.int32) - 32768).astype(np.int16)
+    data_to_save = np.moveaxis(image_int16, -1, 0) if is_color else image_int16
 
-    if is_color:
-        image_to_save = np.moveaxis(image_int16_shifted, -1, 0)
-        final_header['NAXIS'] = 3; final_header['NAXIS1'] = image.shape[1]
-        final_header['NAXIS2'] = image.shape[0]; final_header['NAXIS3'] = 3
-        if 'CTYPE3' not in final_header: final_header['CTYPE3'] = ('RGB', 'Color Format')
-    else: # Grayscale
-        image_to_save = image_int16_shifted
-        final_header['NAXIS'] = 2; final_header['NAXIS1'] = image.shape[1]
-        final_header['NAXIS2'] = image.shape[0]
-        if 'NAXIS3' in final_header: del final_header['NAXIS3']
-        if 'CTYPE3' in final_header: del final_header['CTYPE3']
+    # Filtrer le header fourni: retirer les cartes structurelles (Astropy s’en charge)
+    filtered = fits.Header()
+    if header is not None and isinstance(header, fits.Header):
+        for k, v in header.items():
+            if k not in {"SIMPLE","BITPIX","NAXIS","NAXIS1","NAXIS2","NAXIS3","EXTEND","BSCALE","BZERO"}:
+                filtered[k] = v
 
-    final_header['BITPIX'] = 16; final_header['BSCALE'] = 1; final_header['BZERO'] = 32768
-
-    # --- Write the FITS file WITH warning suppression ---
-    
+    tmp = f"{output_path}.tmp"
     try:
-        hdu = fits.PrimaryHDU(data=image_to_save, header=final_header)
-        hdul = fits.HDUList([hdu])
+        # 1) Créer le HDU sans cartes structurelles manuelles
+        hdu = fits.PrimaryHDU(data=data_to_save)
+        if len(filtered) > 0:
+            hdu.header.update(filtered, update=True)
 
-        # --- Start of the fix ---
+        # 2) Écriture atomique : d’abord .tmp, puis os.replace()
         with warnings.catch_warnings():
-            # Filter settings *inside* the 'with' block
-            warnings.filterwarnings(
-                'ignore',
-                category=VerifyWarning,
-                message="Keyword name.*is greater than 8 characters.*"
-            )
-            warnings.filterwarnings(
-                'ignore',
-                category=VerifyWarning,
-                message="Keyword name.*contains characters not allowed.*"
-            )
+            warnings.filterwarnings("ignore", category=VerifyWarning)
+            hdu.writeto(tmp, overwrite=True, checksum=True)
 
-            # The actual saving function call is *inside* the 'with' block
-            hdul.writeto(output_path, overwrite=overwrite, checksum=True)
-            if final_header.get('BITPIX') == 16:
-                with fits.open(output_path, mode="update", memmap=False) as hdul_fix:
-                    hd0 = hdul_fix[0]
-                    hd0.header["BSCALE"] = 1
-                    hd0.header["BZERO"] = 32768
-                    hdul_fix.flush()
-        
-    except Exception as e:
-        print(f"Error saving FITS file to {output_path}: {e}")
-        # Optional: Add traceback print here if needed for debugging save errors
-        # import traceback
-        # traceback.print_exc(limit=2)
-        # raise # Re-raise if you want saving errors to stop the process
+        # 3) Sanity check minimal FITS
+        if os.path.getsize(tmp) < 2880:
+            raise IOError("FITS too small (<2880 bytes)")
 
+        with fits.open(tmp, mode="update", memmap=False) as hdul:
+            if "SIMPLE" not in hdul[0].header:
+                raise IOError("SIMPLE missing after write")
+            # Conserver la convention unsigned via BZERO/BSCALE pour int16
+            if hdul[0].data is not None and hdul[0].data.dtype.kind == "i" and hdul[0].data.dtype.itemsize == 2:
+                hdul[0].header["BSCALE"] = 1
+                hdul[0].header["BZERO"] = 32768
+                hdul.flush()
 
+        os.replace(tmp, output_path)  # pas de fichier partiellement écrit
+        return True
+
+    except Exception:
+        try:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+        finally:
+            # Laisser l’appelant logger "FITS export failure ..." et SKIP proprement.
+            raise
 
 
 # --- DANS seestar/core/image_processing.py ---


### PR DESCRIPTION
## Summary
- rewrite `save_fits_image` to use atomic `.tmp` writes and replace only after validation
- let Astropy generate structural FITS cards and restore BSCALE/BZERO for int16 data
- clean up incomplete files and surface errors to callers

## Testing
- `pip install opencv-python-headless rasterio`
- `pytest -q` *(fails: AttributeError: module 'seestar.gui.boring_stack' has no attribute 'reproject_utils')*
- `pytest tests/test_reproject_utils.py::test_finalize_coadd_removes_bscale -q` *(fails: ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b229e0fc832f9955222e4993e5f1