### PR TITLE
Fix header header path for batch size 1 aligned FITS temp files

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4231,7 +4231,7 @@ class SeestarQueuedStacker:
                                             )
                                             if img_p and mask_p:
                                                 try:
-                                                    hdr_path = img_p.replace(".npy", ".hdr")
+                                                    hdr_path = os.path.splitext(img_p)[0] + ".hdr"
                                                     with open(hdr_path, "w", encoding="utf-8") as hf:
                                                         hf.write(header_orig.tostring(sep="\n"))
                                                 except Exception as e_hdr:


### PR DESCRIPTION
## Summary
- prevent overwriting aligned FITS files when saving WCS headers for batch size 1

## Testing
- `pytest -q` *(fails: No module named 'rasterio'; No module named 'analyse_logic'; No module named 'stack_plan'; ImportError: attempted relative import with no known parent package; libGL.so.1: cannot open shared object file; ModuleNotFoundError: No module named 'seestar.queuep')*

------
https://chatgpt.com/codex/tasks/task_e_68b6b7c8b61c832f95e85b21e6484b56