### PR TITLE
Enable custom output grid and cropping in streaming reprojection

### DIFF
--- a/seestar/__init__.py
+++ b/seestar/__init__.py
@@ -19,6 +19,8 @@ try:
         save_preview_image,
         estimate_batch_size,
         apply_denoise,  # Keep apply_denoise available if GUI option removed
+        collect_headers,
+        compute_final_output_grid,
     )
     _CORE_AVAILABLE = True
 except Exception as e:  # pragma: no cover - optional dependency may be missing
@@ -81,6 +83,8 @@ if _CORE_AVAILABLE:
         'save_preview_image',
         'estimate_batch_size',
         'apply_denoise',
+        'collect_headers',
+        'compute_final_output_grid',
     ]
 
 if _GUI_AVAILABLE:


### PR DESCRIPTION
## Summary
- expose lightweight `collect_headers` and `compute_final_output_grid`
- add optional output WCS, background matching and footprint cropping to streaming reprojection
- compute and log global output grid in GUI stacker before streaming co-add
- reuse existing core reprojection utilities instead of a separate wrapper

## Testing
- `pytest tests/test_reproject_utils.py -q`
- `pytest tests/test_load_wcs_ignore_missing_simple.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f40e28fc832f946f1daf72bc012b