### PR TITLE
Sanitize WCS headers and equalize batch1 background

### DIFF
--- a/seestar/utils/wcs_utils.py
+++ b/seestar/utils/wcs_utils.py
@@ -29,17 +29,53 @@ def _sanitize_continue_as_string(header: fits.Header) -> None:
         if k == "CONTINUE":
             header[k] = str(v)
 
-def write_wcs_to_fits_inplace(fits_path: str, wcs_obj: WCS) -> None:
+
+def inject_sanitized_wcs(header: fits.Header, wcs_obj: WCS) -> int:
+    """Inject a sanitized WCS solution into ``header``.
+
+    Existing WCS cards and verbose HISTORY/COMMENT entries are removed.
+    Only ASCII values are written, keys are truncated to 8 characters and
+    ``CONTINUE`` cards are skipped.  Returns the number of WCS keywords
+    written to ``header``.
+    """
+
+    _strip_wcs_cards(header)
+    # Purge existing HISTORY/COMMENT
+    for key in ["HISTORY", "COMMENT"]:
+        while key in header:
+            del header[key]
+
+    h_wcs = wcs_obj.to_header(relax=True)
+    count = 0
+    for k, v in h_wcs.items():
+        upk = k.upper()
+        if upk in ("HISTORY", "COMMENT", "CONTINUE"):
+            continue
+        k8 = k[:8]
+        if isinstance(v, str):
+            try:
+                v = v.encode("ascii", "ignore").decode("ascii")
+            except Exception:
+                continue
+        try:
+            header[k8] = v
+            count += 1
+        except Exception:
+            continue
+
+    _sanitize_continue_as_string(header)
+    return count
+
+
+def write_wcs_to_fits_inplace(fits_path: str, wcs_obj: WCS) -> int:
     """Persist ``wcs_obj`` into ``fits_path`` updating header only.
 
     The FITS file is opened with ``memmap=True`` and data are left untouched.
     Any previous WCS cards are removed before injecting the new solution.
+    Returns the number of WCS keywords written.
     """
     with fits.open(fits_path, mode="update", memmap=True) as hdul:
         h = hdul[0].header
-        _strip_wcs_cards(h)
-        h_wcs = wcs_obj.to_header(relax=True)
-        for k, v in h_wcs.items():
-            h[k] = v
-        _sanitize_continue_as_string(h)
+        count = inject_sanitized_wcs(h, wcs_obj)
         hdul.flush()
+    return count


### PR DESCRIPTION
## Summary
- sanitize and inject ASCII-only WCS headers when writing batch-1 aligned temps
- equalize background for batch size 1 before stacking with sigma-clipped medians
- crop final reprojected stacks to weight-map bounds and update WCS metadata

## Testing
- `pytest` *(fails: ModuleNotFoundError: analyse_logic, others)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fd90cd18832f88ec14ca5f370349