### PR TITLE
Add guard for large mosaics in reprojection

### DIFF
--- a/seestar/enhancement/reproject_utils.py
+++ b/seestar/enhancement/reproject_utils.py
@@ -68,6 +68,14 @@ def reproject_and_coadd(
     ref_wcs = WCS(output_projection) if not isinstance(output_projection, WCS) else output_projection
     shape_out = tuple(int(round(x)) for x in shape_out)
 
+    mem_required = np.prod(shape_out) * 2 * 8 / 1024**3
+    max_mem = float(os.environ.get("REPROJECT_MAX_ARRAY_GB", "64"))
+    if mem_required > max_mem:
+        raise MemoryError(
+            f"Output shape {shape_out} requires {mem_required:.1f} GiB; "
+            f"limit is {max_mem:.1f} GiB. Reduce the output size or process in tiles."
+        )
+
     weights_iter = input_weights if input_weights is not None else [None] * len(input_data)
     filtered_pairs = []
     filtered_weights = []

--- a/tests/test_reproject_utils.py
+++ b/tests/test_reproject_utils.py
@@ -166,3 +166,28 @@ def test_memory_threshold_forces_fallback(monkeypatch):
     assert np.allclose(result, 1)
     assert np.allclose(cov, 1)
     assert called["n"] == 0
+
+
+def test_memory_limit_raises(monkeypatch):
+    module = reproject_utils
+
+    monkeypatch.setenv("REPROJECT_MEM_THRESHOLD_GB", "0")
+    monkeypatch.setenv("REPROJECT_MAX_ARRAY_GB", "0")
+
+    def dummy_reproj(data_wcs, output_projection=None, shape_out=None, **kwargs):
+        data, _ = data_wcs
+        return data[: shape_out[0], : shape_out[1]], np.ones(shape_out, dtype=float)
+
+    from astropy.wcs import WCS
+    import numpy as np
+
+    wcs = WCS(naxis=2)
+    wcs.pixel_shape = (1, 1)
+
+    with pytest.raises(MemoryError):
+        module.reproject_and_coadd(
+            [(np.ones((1, 1), dtype=np.float32), wcs)],
+            output_projection=wcs,
+            shape_out=(1, 1),
+            reproject_function=dummy_reproj,
+        )


### PR DESCRIPTION
## Summary
- prevent `reproject_and_coadd` from allocating arrays larger than a configurable limit
- add regression test ensuring MemoryError when limit is exceeded

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rasterio')*
- `pytest tests/test_reproject_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b720e9a0dc832fa27adcb4014e3536