### PR TITLE
Improve batch-1 reproject with WCS sanitization and streaming fallback

### DIFF
--- a/seestar/core/streaming_stack.py
+++ b/seestar/core/streaming_stack.py
@@ -261,3 +261,41 @@ def stack_disk_streaming(
         len(file_list),
     )
     return out_path
+
+
+# -----------------------------------------------------------------------------
+# Reprojection streaming wrapper
+# -----------------------------------------------------------------------------
+
+from astropy.stats import sigma_clip
+from astropy.wcs import WCS
+
+
+def _subtract_sky_median(image, nsig: float = 3.0, maxiters: int = 5):
+    clipped = sigma_clip(image, sigma=nsig, maxiters=maxiters)
+    med = np.nanmedian(clipped)
+    return image - (0.0 if not np.isfinite(med) else float(med))
+
+
+def streaming_reproject_and_coadd(
+    aligned_paths: Sequence[str],
+    output_wcs: WCS | None = None,
+    shape_out: tuple[int, int] | None = None,
+    subtract_sky_median: bool = True,
+    **kwargs,
+):
+    """Proxy to enhancement.streaming_reproject_and_coadd.
+
+    This thin wrapper lives in ``core`` to avoid circular imports while
+    offering a stable entry point for higher level modules.
+    """
+
+    from ..enhancement.reproject_utils import streaming_reproject_and_coadd as _impl
+
+    return _impl(
+        aligned_paths,
+        output_wcs=output_wcs,
+        shape_out=shape_out,
+        subtract_sky_median=subtract_sky_median,
+        **kwargs,
+    )


### PR DESCRIPTION
## Summary
- sanitize ASTAP WCS text before FITS parsing and log modifications
- validate WCS and guard memory in reproject; add streaming fallback with optional sky median subtraction
- expose streaming reprojection helper in core and hook batch-1 pipeline

## Testing
- `pytest tests/test_astrometry_solver.py tests/test_astap_wcs_padding.py tests/test_reproject_utils.py tests/test_streaming_stack_parallel.py tests/test_streaming_stack_orientation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b72ca91d8c832f920bba546765db3d