### PR TITLE
Fix batch1 reproject cropping

### DIFF
--- a/seestar/enhancement/reproject_utils.py
+++ b/seestar/enhancement/reproject_utils.py
@@ -263,7 +263,9 @@ def reproject_and_coadd(
         _reproject_interp()
 
     kwargs = dict(kwargs)  # [B1-COADD-FIX]
-    kwargs.pop("return_footprint", None)  # [B1-COADD-FIX]
+    # Ne jamais transmettre ces flags UI/streaming au moteur de reprojection
+    kwargs.pop("return_footprint", None)      # ok pour astropy
+    kwargs.pop("crop_to_footprint", None)     # sinon -> TypeError dans reproject_interp
 
     ref_wcs = WCS(output_projection) if not isinstance(output_projection, WCS) else output_projection
     shape_out = tuple(int(round(x)) for x in shape_out)

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -10534,7 +10534,9 @@ class SeestarQueuedStacker:
 
         final_chw, wht_map, out_wcs = result
         img_hwc = np.transpose(final_chw, (1, 2, 0))
-        cov_hw = wht_map if wht_map.ndim == 2 else wht_map[0]
+        cov_hw  = wht_map if wht_map.ndim == 2 else wht_map[0]
+        # 👉 rognage identique au mode non-BS1
+        img_hwc, cov_hw, out_wcs = self._crop_to_wht_bbox(img_hwc, cov_hw, out_wcs)
         self.current_stack = img_hwc.astype(np.float32)
         self.current_coverage = cov_hw.astype(np.float32)
         self.current_stack_header = fits.Header()


### PR DESCRIPTION
## Summary
- avoid forwarding crop_to_footprint to astropy reproject
- crop batch-size=1 mosaics to WHT bounding box after coadd

## Testing
- `pytest -q` *(fails: No module named 'rasterio'; No module named 'analyse_logic'; ImportError: libGL.so.1: cannot open shared object file; ModuleNotFoundError: No module named 'seestar.queuep')*

------
https://chatgpt.com/codex/tasks/task_e_68b8544904c0832fa23dfe328a1db818