### PR TITLE
Handle ReprojectCoaddResult for batch-1 mode

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -454,9 +454,6 @@ def _finalize_reproject_and_coadd(
         if _qm_renorm is not None:
             _qm_renorm(out_fp, method="n_images", n_images=n_inputs)
         else:
-            from astropy.io import fits
-            import numpy as np
-
             with fits.open(out_fp, mode="update") as hdul:
                 data = hdul[0].data
                 hdr = hdul[0].header

--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -10532,9 +10532,20 @@ class SeestarQueuedStacker:
                 prefer_streaming_fallback=True,
             )
 
-        final_chw, wht_map, out_wcs = result
-        img_hwc = np.transpose(final_chw, (1, 2, 0))
-        cov_hw  = wht_map if wht_map.ndim == 2 else wht_map[0]
+        if hasattr(result, "image"):
+            img_hwc = result.image
+            wht_map = result.weight
+            out_wcs = result.wcs
+            if (
+                img_hwc.ndim == 3
+                and img_hwc.shape[0] in (1, 3, 4)
+                and img_hwc.shape[0] != img_hwc.shape[-1]
+            ):
+                img_hwc = np.transpose(img_hwc, (1, 2, 0))
+        else:
+            final_chw, wht_map, out_wcs = result
+            img_hwc = np.transpose(final_chw, (1, 2, 0))
+        cov_hw = wht_map if wht_map.ndim == 2 else wht_map[0]
         # 👉 rognage identique au mode non-BS1
         img_hwc, cov_hw, out_wcs = self._crop_to_wht_bbox(img_hwc, cov_hw, out_wcs)
         self.current_stack = img_hwc.astype(np.float32)


### PR DESCRIPTION
## Summary
- adapt batch-size=1 queue manager to consume `ReprojectCoaddResult`
- remove shadowing imports in boring stack normalisation routine

## Testing
- `pytest` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b87a07d590832fa47568c141133752