### PR TITLE
Fix indentation in queue manager WCS injection

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -13692,7 +13692,7 @@ class SeestarQueuedStacker:
                         hdr_src = fits.getheader(src_fp, memmap=False)
 
                         inject_sanitized_wcs(hdr, hdr_src)
-     except Exception:
+                    except Exception:
                         pass
 
                 h = int(data.shape[0]) if data.ndim >= 2 else 0


### PR DESCRIPTION
## Summary
- fix indentation causing ImportError in queue_manager's WCS fallback path

## Testing
- `xvfb-run -a pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9df181984832fad5cbd4f9323f7b8