### PR TITLE
Fix empty final coadd for batch-size=1

### DIFF
--- a/seestar/gui/boring_stack.py
+++ b/seestar/gui/boring_stack.py
@@ -441,6 +441,7 @@ def _finalize_reproject_and_coadd(
             shape_out=shape_out,
             prefer_streaming_fallback=prefer_streaming_fallback,
             tile_size=tile_size,
+            match_background=False,
         )
         hdr_out = ref_wcs.to_header(relax=True)
     else:
@@ -464,6 +465,7 @@ def _finalize_reproject_and_coadd(
                 shape_out=shape_out,
                 prefer_streaming_fallback=prefer_streaming_fallback,
                 tile_size=tile_size,
+                match_background=False,
             )
             hdr_out = ref_wcs.to_header(relax=True)
         except Exception as e:
@@ -474,6 +476,7 @@ def _finalize_reproject_and_coadd(
                 paths,
                 prefer_streaming_fallback=prefer_streaming_fallback,
                 tile_size=tile_size,
+                match_background=False,
             )
             hdr_out = result.wcs.to_header(relax=True)
 
@@ -489,6 +492,7 @@ def _finalize_reproject_and_coadd(
             paths,
             prefer_streaming_fallback=prefer_streaming_fallback,
             tile_size=tile_size,
+            match_background=False,
         )
         hdr_out = result.wcs.to_header(relax=True)
 


### PR DESCRIPTION
## Summary
- avoid astropy background matching during batch-size 1 final coadd to prevent empty mosaics

## Testing
- `pytest tests/test_reproject_utils.py tests/test_queue_manager_reproject.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb173000e8832f9faab6a5622c06e4