### PR TITLE
Ensure background matching toggle respects batch_size=1 reprojection

### DIFF
--- a/seestar/enhancement/reproject_utils.py
+++ b/seestar/enhancement/reproject_utils.py
@@ -459,6 +459,10 @@ def reproject_and_coadd_from_paths(
 
     if match_background is not None:
         subtract_sky_median = match_background
+        # Propagate the user's preference to the underlying coadd call so that
+        # ``reproject_and_coadd`` respects explicit enable/disable requests
+        # (especially important for ``batch_size=1`` workflows).
+        kwargs["match_background"] = bool(match_background)
 
     if shape_out is not None:
         mem_threshold = float(os.environ.get("REPROJECT_MEM_THRESHOLD_GB", "8"))


### PR DESCRIPTION
## Summary
- Forward `match_background` flag in `reproject_and_coadd_from_paths` so `reproject_and_coadd` honors user preference
- Prevent unwanted background matching that could yield empty mosaics in batch-size=1 runs

## Testing
- `pytest tests/test_queue_manager_reproject.py::test_reproject_classic_batches_disables_match_bg_for_bs1 -q`
- `pytest -q` *(fails: ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running)*

------
https://chatgpt.com/codex/tasks/task_e_68bb20d317e8832fbc55f2db1fb5c093