### PR TITLE
Fix final stack scaling for batch_size=1

### DIFF
--- a/tests/test_save_final_stack.py
+++ b/tests/test_save_final_stack.py
@@ -407,3 +407,24 @@ def test_save_final_stack_radec_from_reference_header(tmp_path):
     assert np.isclose(hdr["RA"], 12.34)
     assert np.isclose(hdr["DEC"], 56.78)
 
+
+def test_save_final_stack_batch1_negative_int16(tmp_path):
+    obj = _make_obj(tmp_path, False)
+    obj.batch_size = 1
+    obj.reproject_between_batches = True
+    obj.preserve_linear_output = True
+
+    data = np.array([[-2.0, -1.0], [-1.5, 0.0]], dtype=np.float32)
+    wht = np.ones_like(data, dtype=np.float32)
+
+    qm.SeestarQueuedStacker._save_final_stack(
+        obj,
+        output_filename_suffix="_classic_reproject",
+        drizzle_final_sci_data=data,
+        drizzle_final_wht_data=wht,
+        preserve_linear_output=True,
+    )
+
+    saved = fits.getdata(obj.final_stacked_path)
+    assert np.max(saved) > 0
+


### PR DESCRIPTION
## Summary
- preserve negative values when saving single-batch stacks
- normalize batch_size=1 data before uint16 conversion
- add regression test for batch_size=1 negative data

## Testing
- `pytest tests/test_save_final_stack.py -q`
- `pytest -q` *(fails: ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2ef03f50832f9b8323639eefd438