### PR TITLE
Disable RA/DEC hints for ASTAP solves

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -3625,8 +3625,6 @@ class SeestarQueuedStacker:
                 "astrometry_net_timeout_sec": getattr(
                     self, "astrometry_net_timeout_sec", 300
                 ),
-                # Hints can dramatically speed ASTAP when RA/DEC are present
-                "use_radec_hints": True,
             }
             # (Vos logs pour le contenu de solver_settings_for_ref_anchor peuvent rester ici)
             logger.debug(
@@ -13151,8 +13149,6 @@ class SeestarQueuedStacker:
                     "astrometry_net_timeout_sec": getattr(
                         self, "astrometry_net_timeout_sec", 300
                     ),
-                    # Speed up ASTAP when RA/DEC are available in the header
-                    "use_radec_hints": True,
                 }
 
                 self.update_progress(


### PR DESCRIPTION
## Summary
- Remove `use_radec_hints` from reference anchor solving
- Remove `use_radec_hints` from StartProcRefSolve ASTAP call

## Testing
- `pytest -q` *(fails: ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework)*
- `pytest tests/test_astrometry_solver.py tests/test_mosaic_worker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb4572bcc0832fa27bfe2a91b5002b