### PR TITLE
Fix batch size 0 stack plan grouping

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -4299,12 +4299,14 @@ class SeestarQueuedStacker:
                                 )
                                 self._current_batch_paths.append(file_path)
 
-                                trigger = (
-                                    getattr(self, "chunk_size", None)
-                                    if self.batch_size == 1
-                                    and getattr(self, "chunk_size", None)
-                                    else max(1, self.batch_size)
-                                )
+                                if self.batch_size == 0:
+                                    trigger = float("inf")
+                                elif self.batch_size == 1 and getattr(
+                                    self, "chunk_size", None
+                                ):
+                                    trigger = getattr(self, "chunk_size")
+                                else:
+                                    trigger = max(1, self.batch_size)
                                 if (
                                     len(current_batch_items_with_masks_for_stack_batch)
                                     >= trigger
@@ -4536,12 +4538,14 @@ class SeestarQueuedStacker:
                                             classic_stack_item
                                         )
 
-                                trigger = (
-                                    getattr(self, "chunk_size", None)
-                                    if self.batch_size == 1
-                                    and getattr(self, "chunk_size", None)
-                                    else max(1, self.batch_size)
-                                )
+                                if self.batch_size == 0:
+                                    trigger = float("inf")
+                                elif self.batch_size == 1 and getattr(
+                                    self, "chunk_size", None
+                                ):
+                                    trigger = getattr(self, "chunk_size")
+                                else:
+                                    trigger = max(1, self.batch_size)
                                 if (
                                     len(current_batch_items_with_masks_for_stack_batch)
                                     >= trigger


### PR DESCRIPTION
## Summary
- avoid premature batch flush when batch size is 0 so stack_plan.csv groups are preserved
- keep existing behavior for batch size 1 and other sizes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf27880f8832fae0016d40b205cc0