### PR TITLE
fix: avoid solving classic batches in batch_size=0 mode

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -10737,7 +10737,7 @@ class SeestarQueuedStacker:
                             has_wcs = True
                         except Exception:
                             has_wcs = False
-                    if not has_wcs:
+                    if not has_wcs and getattr(self, "batch_size", 0) != 0:
                         try:
                             self._run_astap_and_update_header(sci_path)
                             hdr = fits.getheader(sci_path, memmap=False)


### PR DESCRIPTION
## Summary
- ensure reproject+coadd reuses reference WCS and skips solving for classic batches when `batch_size` is zero

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdfc9ec680832f94c710e102d17459