### PR TITLE
Ensure WCS pixel shapes after instantiation

### DIFF
--- a/seestar/enhancement/reproject_utils.py
+++ b/seestar/enhancement/reproject_utils.py
@@ -104,9 +104,10 @@ def compute_final_output_grid(headers, auto_rotate=True):
     for hdr in headers:
         try:
             hdr = sanitize_header_for_wcs(hdr)
-            w = WCS(hdr, naxis=2)
             h = int(hdr.get("NAXIS2"))
             w_pix = int(hdr.get("NAXIS1"))
+            w = WCS(hdr, naxis=2)
+            ensure_wcs_pixel_shape(w, h, w_pix)
             wcs_list.append(w)
             shapes.append((h, w_pix))
         except Exception:


### PR DESCRIPTION
## Summary
- enforce WCS pixel_shape during final grid computation
- validate pixel shape on queue manager WCS creation with robust import

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ensure_wcs_pixel_shape' / missing SeestarQueuedStacker)*

------
https://chatgpt.com/codex/tasks/task_e_68be1450ff78832fb00daabd0eb9b277