### PR TITLE
Ensure batch-size zero reproject mode mirrors WIP workflow

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -13473,6 +13473,8 @@ class SeestarQueuedStacker:
 
         if reproject_coadd_final is not None:
             self.reproject_coadd_final = bool(reproject_coadd_final)
+            if self.reproject_coadd_final:
+                self.stack_final_combine = "reproject_coadd"
         logger.debug(
             f"    [OutputFormat] self.reproject_coadd_final (attribut d'instance) mis à : {self.reproject_coadd_final} (depuis argument {reproject_coadd_final})"
         )
@@ -13565,6 +13567,7 @@ class SeestarQueuedStacker:
             self.batch_size = 0
             if reproject_coadd_final is None and not self.reproject_coadd_final:
                 self.reproject_coadd_final = True
+                self.stack_final_combine = "reproject_coadd"
                 self.update_progress(
                     "ⓘ batch_size=0 : activation automatique de Reproject&Coadd (comportement WIP).",
                     None,
@@ -13572,6 +13575,8 @@ class SeestarQueuedStacker:
                 logger.debug(
                     "  -> batch_size=0: reproject_coadd_final forcé à True pour reproduire le workflow WIP."
                 )
+            elif self.reproject_coadd_final and getattr(self, "stack_final_combine", "").lower() != "reproject_coadd":
+                self.stack_final_combine = "reproject_coadd"
         elif requested_batch_size < 0:
             sample_img_path_for_bsize = None
             if input_dir and os.path.isdir(input_dir):

--- a/tests/test_queue_manager_reproject.py
+++ b/tests/test_queue_manager_reproject.py
@@ -635,6 +635,7 @@ def test_start_processing_prepares_grid_on_freeze(monkeypatch, tmp_path):
 
     assert ok
     assert called["grid"]
+    assert obj.stack_final_combine == "reproject_coadd"
 
 
 def test_start_processing_bs0_defaults_to_reproject_coadd(monkeypatch, tmp_path):
@@ -742,6 +743,7 @@ def test_start_processing_bs0_defaults_to_reproject_coadd(monkeypatch, tmp_path)
 
     assert ok
     assert obj.reproject_coadd_final is True
+    assert obj.stack_final_combine == "reproject_coadd"
 
 
 def test_reproject_coadd_skips_solver_when_wcs_present(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- align `stack_final_combine` with the reproject-and-coadd workflow when batch size zero triggers the WIP behaviour in `start_processing`
- extend the queue manager batch-size zero tests to assert the expected final-combine mode

## Testing
- pytest tests/test_queue_manager_reproject.py -k "bs0" -q

------
https://chatgpt.com/codex/tasks/task_e_68cb03c5c36c832f8946b2b86d18ed90