### PR TITLE
Align batch-size zero reproject mode with WIP workflow

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -13565,6 +13565,20 @@ class SeestarQueuedStacker:
         if requested_batch_size == 0:
             # Mode "batch size 0" explicite : aucun lot, tout en RAM
             self.batch_size = 0
+            if self.reproject_between_batches:
+                self.update_progress(
+                    "ⓘ batch_size=0 : désactivation de la reprojection entre lots (workflow WIP).",
+                    None,
+                )
+                logger.debug(
+                    "  -> batch_size=0: reproject_between_batches forcé à False pour reproduire WIP."
+                )
+                self.reproject_between_batches = False
+            if not self.freeze_reference_wcs:
+                logger.debug(
+                    "  -> batch_size=0: freeze_reference_wcs activé pour conserver la grille WIP."
+                )
+                self.freeze_reference_wcs = True
             if reproject_coadd_final is None and not self.reproject_coadd_final:
                 self.reproject_coadd_final = True
                 self.stack_final_combine = "reproject_coadd"

--- a/tests/test_queue_manager_reproject.py
+++ b/tests/test_queue_manager_reproject.py
@@ -746,6 +746,123 @@ def test_start_processing_bs0_defaults_to_reproject_coadd(monkeypatch, tmp_path)
     assert obj.stack_final_combine == "reproject_coadd"
 
 
+def test_bs0_reproject_disables_inter_batch(monkeypatch, tmp_path):
+    sys.path.insert(0, str(ROOT))
+    import importlib
+    import types
+    import os
+
+    if "seestar.gui" not in sys.modules:
+        seestar_pkg = types.ModuleType("seestar")
+        seestar_pkg.__path__ = [str(ROOT / "seestar")]
+        gui_pkg = types.ModuleType("seestar.gui")
+        gui_pkg.__path__ = []
+        settings_mod = types.ModuleType("seestar.gui.settings")
+
+        class DummySettingsManager:
+            pass
+
+        settings_mod.SettingsManager = DummySettingsManager
+        hist_mod = types.ModuleType("seestar.gui.histogram_widget")
+        hist_mod.HistogramWidget = object
+        gui_pkg.settings = settings_mod
+        gui_pkg.histogram_widget = hist_mod
+        seestar_pkg.gui = gui_pkg
+        sys.modules["seestar"] = seestar_pkg
+        sys.modules["seestar.gui"] = gui_pkg
+        sys.modules["seestar.gui.settings"] = settings_mod
+        sys.modules["seestar.gui.histogram_widget"] = hist_mod
+
+    qm = importlib.import_module("seestar.queuep.queue_manager")
+
+    obj = qm.SeestarQueuedStacker()
+    obj.update_progress = lambda *a, **k: None
+    obj.autotuner = None
+    obj.freeze_reference_wcs = False
+    obj.reproject_coadd_final = False
+    obj.reproject_between_batches = True
+    obj.drizzle_active_session = False
+    obj.batch_size = 0
+    obj.current_folder = str(tmp_path)
+    obj.output_folder = str(tmp_path)
+    obj.queue = qm.Queue()
+    obj.additional_folders = []
+    obj.stack_final_combine = "mean"
+
+    from astropy.io import fits
+
+    wcs = make_wcs(shape=(4, 4))
+    hdr = wcs.to_header()
+    data = np.zeros((4, 4), dtype=np.float32)
+    ref_path = tmp_path / "ref.fits"
+    fits.writeto(ref_path, data, hdr, overwrite=True)
+
+    class DummyAligner:
+        def __init__(self):
+            self.stop_processing = False
+            self.reference_image_path = None
+            self.correct_hot_pixels = False
+            self.hot_pixel_threshold = 0.0
+            self.neighborhood_size = 0
+            self.bayer_pattern = "GRBG"
+
+        def _get_reference_image(self, folder, files, output_folder):
+            hdr_local = fits.getheader(os.path.join(folder, files[0]))
+            temp_dir = os.path.join(output_folder, "temp_processing")
+            os.makedirs(temp_dir, exist_ok=True)
+            out_path = os.path.join(temp_dir, "reference_image.fit")
+            fits.writeto(out_path, np.zeros((4, 4), dtype=np.float32), hdr_local, overwrite=True)
+            self.reference_image_path = out_path
+            return np.zeros((4, 4, 3), dtype=np.float32), hdr_local
+
+    obj.aligner = DummyAligner()
+
+    def fake_add_files(folder):
+        obj.queue.put(str(ref_path))
+        obj.all_input_filepaths = [str(ref_path)]
+        obj.files_in_queue = 1
+        return 1
+
+    obj._add_files_to_queue = fake_add_files
+
+    class DummySolver:
+        def solve(
+            self,
+            path,
+            hdr,
+            settings,
+            update_header_with_solution=False,
+            batch_size=None,
+            final_combine=None,
+        ):
+            return wcs
+
+    obj.astrometry_solver = DummySolver()
+
+    def fake_prepare():
+        obj.reference_wcs_object = wcs
+        obj.reference_shape = (4, 4)
+        obj.reference_header_for_wcs = wcs.to_header(relax=True)
+        return True
+
+    monkeypatch.setattr(obj, "_prepare_global_reprojection_grid", fake_prepare)
+
+    obj._worker = lambda: None
+
+    ok = obj.start_processing(
+        str(tmp_path),
+        str(tmp_path),
+        batch_size=0,
+        reproject_coadd_final=True,
+        reproject_between_batches=True,
+    )
+
+    assert ok
+    assert obj.reproject_between_batches is False
+    assert obj.freeze_reference_wcs is True
+    assert obj.stack_final_combine == "reproject_coadd"
+
+
 def test_reproject_coadd_skips_solver_when_wcs_present(monkeypatch, tmp_path):
     sys.path.insert(0, str(ROOT))
     import importlib


### PR DESCRIPTION
## Summary
- Disable inter-batch reprojection and freeze the reference WCS when batch_size=0 to match the WIP live workflow.
- Ensure stack_final_combine remains set to reproject_coadd when forcing the WIP behaviour.
- Add a regression test covering the automatic WIP configuration for batch_size=0 with reproject+coadd.

## Testing
- `pytest tests/test_queue_manager_reproject.py -k "bs0" -q`


------
https://chatgpt.com/codex/tasks/task_e_68cb0aaf8790832fb90d3d119fdbf0fa