### PR TITLE
Improve blank detection for batch-size zero coadds

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -11749,7 +11749,11 @@ class SeestarQueuedStacker:
                             return True
                         if not np.any(np.nan_to_num(cov_arr, nan=0.0) > 0):
                             return True
-                        if np.nanmax(np.abs(sci_arr)) <= 1e-7:
+                        max_abs = float(np.nanmax(np.abs(sci_arr)))
+                        if max_abs <= 1e-7:
+                            return True
+                        range_val = float(np.nanmax(sci_arr) - np.nanmin(sci_arr))
+                        if range_val <= 5e-5:
                             return True
                     except Exception:
                         return False


### PR DESCRIPTION
## Summary
- treat near-constant coadd outputs as blank when batch_size is zero so the workflow falls back to the local accumulator
- add regression coverage ensuring low-range astropy results trigger the batch-size zero fallback

## Testing
- pytest tests/test_queue_manager_reproject.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc55ca8d40832fbf1e21158365e756