### PR TITLE
Align batch_size=0 reproject path with WIP behaviour

### DIFF
--- a/seestar/queuep/queue_manager.py
+++ b/seestar/queuep/queue_manager.py
@@ -10854,9 +10854,10 @@ class SeestarQueuedStacker:
                 h, w = data_cxhxw.shape[-2:]
                 if getattr(self, "batch_size", 0) == 0 and self.reference_wcs_object is not None:
                     batch_wcs = self.reference_wcs_object
+                    batch_wcs.pixel_shape = (w, h)
                 else:
                     batch_wcs = WCS(hdr, naxis=2)
-                ensure_wcs_pixel_shape(batch_wcs, h, w)
+                    ensure_wcs_pixel_shape(batch_wcs, h, w)
             except Exception:
                 continue  # silently skip unreadable batch
 
@@ -10866,8 +10867,7 @@ class SeestarQueuedStacker:
                     np.float32, copy=False
                 )
                 np.nan_to_num(coverage, copy=False)
-                if int(getattr(self, "batch_size", 0) or 0) == 1:
-                    coverage *= make_radial_weight_map(*coverage.shape)
+                coverage *= make_radial_weight_map(*coverage.shape)
             except Exception:
                 coverage = np.ones((h, w), dtype=np.float32)
 
@@ -10919,51 +10919,17 @@ class SeestarQueuedStacker:
         final_channels = []
         final_cov = None
 
-        import os as _os
-
-        def _set_force_local(value):
-            if value is None:
-                try:
-                    del _os.environ["REPROJECT_FORCE_LOCAL"]
-                except KeyError:
-                    pass
-            else:
-                _os.environ["REPROJECT_FORCE_LOCAL"] = value
-
-        def _is_blank(_sci, _cov):
-            try:
-                if _sci is None or _cov is None:
-                    return True
-                sci_arr = np.asarray(_sci, dtype=np.float32)
-                cov_arr = np.asarray(_cov, dtype=np.float32)
-                if not np.any(np.isfinite(sci_arr)):
-                    return True
-                if not np.any(np.nan_to_num(cov_arr, nan=0.0) > 0):
-                    return True
-                max_abs = float(np.nanmax(np.abs(sci_arr)))
-                if max_abs <= 1e-7:
-                    return True
-                range_val = float(np.nanmax(sci_arr) - np.nanmin(sci_arr))
-                if range_val <= 5e-5:
-                    return True
-            except Exception:
-                return False
-            return False
-
-        try:
-            bs_local = int(getattr(self, "batch_size", 0) or 0)
-        except Exception:
-            bs_local = 0
-        prev_force = _os.environ.get("REPROJECT_FORCE_LOCAL")
-
         for ch in range(3):
-            # When stacking classic batches in ``batch_size in {0, 1}`` mode, images
+            # When stacking classic batches in ``batch_size == 1`` mode, images
             # are already background normalised during the disk-based pipeline.
             # Passing ``match_background=True`` to ``reproject_and_coadd`` would
             # attempt another background matching step, which can result in NaNs
             # when some inputs have no overlap, producing an empty final image.
-            # Keep the previous behaviour for larger batch sizes only.
-            match_bg = bs_local > 1
+            # Keep the previous behaviour for other batch sizes.
+            try:  # [B1-MATCH-BG-FIX]
+                match_bg = getattr(self, "batch_size", 0) != 1
+            except Exception:
+                match_bg = True
 
             sci, cov = reproject_and_coadd(
                 channel_arrays_wcs[ch],
@@ -10975,28 +10941,9 @@ class SeestarQueuedStacker:
                 match_background=match_bg,
             )
 
-            if bs_local == 0 and prev_force != "1" and _is_blank(sci, cov):
-                self.update_progress(
-                    "   ⚠️ Reproject (astropy) a renvoyé une image vide – bascule sur l'accumulateur local.",
-                    "WARN",
-                )
-                _set_force_local("1")
-                try:
-                    sci, cov = reproject_and_coadd(
-                        channel_arrays_wcs[ch],
-                        output_projection=out_wcs,
-                        shape_out=out_shape,
-                        input_weights=channel_footprints[ch],
-                        reproject_function=reproject_interp,
-                        combine_function="mean",
-                        match_background=match_bg,
-                    )
-                finally:
-                    _set_force_local(prev_force)
-
-            final_channels.append(np.asarray(sci, dtype=np.float32))
+            final_channels.append(sci.astype(np.float32))
             if final_cov is None:
-                final_cov = np.asarray(cov, dtype=np.float32)
+                final_cov = cov.astype(np.float32)
 
         data_hwc = np.stack(final_channels, axis=-1)
         cov_hw = final_cov

--- a/tests/test_queue_manager_reproject.py
+++ b/tests/test_queue_manager_reproject.py
@@ -1395,7 +1395,7 @@ def _prepare_qm_env(monkeypatch, tmp_path, batch_size):
     ]
 
 
-def test_reproject_classic_batches_disables_match_bg_for_bs0(monkeypatch, tmp_path):
+def test_reproject_classic_batches_keeps_match_bg_for_bs0(monkeypatch, tmp_path):
     obj, batch_files = _prepare_qm_env(monkeypatch, tmp_path, batch_size=0)
     import seestar.enhancement.reproject_utils as ru
 
@@ -1416,7 +1416,7 @@ def test_reproject_classic_batches_disables_match_bg_for_bs0(monkeypatch, tmp_pa
 
     obj._reproject_classic_batches(batch_files)
 
-    assert captured.get("match_background") is False
+    assert captured.get("match_background") is True
 
 
 def test_reproject_classic_batches_disables_match_bg_for_bs1(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- set the reference WCS pixel_shape when reprojecting batch_size=0 classic batches so the test branch mirrors WIP's geometry handling
- remove the local reproject fallback and restore the WIP background-matching logic to keep batch_size=0 reproject+coadd outputs aligned

## Testing
- pytest tests/test_queue_manager_reproject.py -k "match_bg or keeps_match_bg_for_bs0" -q

------
https://chatgpt.com/codex/tasks/task_e_68cc6984919c832f93e65082faf76cc4