### PR TITLE
Ensure batch-size zero reproject uses match background normalization

### DIFF
--- a/seestar/gui/main_window.py
+++ b/seestar/gui/main_window.py
@@ -6442,14 +6442,13 @@ class SeestarStackerGUI:
                         self.gui_event_queue.put(_apply_valid)
                     else:
                         self.root.after(0, _apply_valid)
-                if hasattr(self.settings, "match_background_for_final"):
-                    match_background_for_final = bool(
-                        getattr(self.settings, "match_background_for_final", False)
-                    )
+                raw_match_bg = getattr(
+                    self.settings, "match_background_for_final", None
+                )
+                if raw_match_bg is None:
+                    match_background_for_final = None
                 else:
-                    match_background_for_final = (
-                        self.settings.stack_final_combine == "reproject_coadd"
-                    )
+                    match_background_for_final = bool(raw_match_bg)
 
                 backend_kwargs = {
                     "input_dir": self.settings.input_folder,

--- a/seestar/gui/settings.py
+++ b/seestar/gui/settings.py
@@ -1238,6 +1238,7 @@ class SettingsManager:
         defaults_dict["stack_winsor_limits"] = "0.05,0.05"
         # Default final combination method
         defaults_dict["stack_final_combine"] = "mean"
+        defaults_dict["match_background_for_final"] = None
         defaults_dict["max_hq_mem_gb"] = 8
         defaults_dict["stack_method"] = "kappa_sigma"
         defaults_dict["correct_hot_pixels"] = True


### PR DESCRIPTION
## Summary
- default the queue manager's `match_background_for_final` flag to `None` so that batch size 0 and multi-batch runs enable `reproject`'s background matching by default while keeping batch size 1 disabled unless explicitly requested
- update the GUI settings defaults and start-processing pipeline to propagate a tri-state `match_background_for_final` preference instead of forcing `False`
- keep batch-size 1 behaviour unchanged while ensuring batch-size 0 maintains inter-batch normalization through the final coadd stage

## Testing
- `pytest tests/test_queue_manager_reproject.py::test_reproject_classic_batches_keeps_match_bg_for_bs0 tests/test_queue_manager_reproject.py::test_reproject_classic_batches_disables_match_bg_for_bs1 tests/test_queue_manager_reproject.py::test_reproject_classic_batches_keeps_match_bg_for_bs2 -q`


------
https://chatgpt.com/codex/tasks/task_e_68f0b7469810832f83074f7bc0daef8f